### PR TITLE
feat: remove old urls

### DIFF
--- a/kardinal-cli/cmd/root.go
+++ b/kardinal-cli/cmd/root.go
@@ -4,24 +4,23 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
+	"net/http"
+
 	"github.com/compose-spec/compose-go/cli"
 	"github.com/compose-spec/compose-go/types"
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/spf13/cobra"
 	"kardinal.cli/deployment"
 	"kardinal.cli/tenant"
-	"log"
-	"net/http"
 
 	api "github.com/kurtosis-tech/kardinal/libs/cli-kontrol-api/api/golang/client"
 	api_types "github.com/kurtosis-tech/kardinal/libs/cli-kontrol-api/api/golang/types"
 )
 
 const (
-	projectName          = "kardinal"
-	devMode              = false
-	kontrolServiceApiUrl = "ad718d90d54d54dd084dea50a9f011af-1140086995.us-east-1.elb.amazonaws.com"
-	kontrolServicePort   = 8080
+	projectName = "kardinal"
+	devMode     = false
 
 	kontrolLocationLocalMinikube = "local-minikube"
 	kontrolLocationKloudKontrol  = "kloud-kontrol"


### PR DESCRIPTION
removes unused kontrol service urls - these are replaced by `kloudKontrolApiHost=app.kardinal.dev/api`