### PR TITLE
feat: More robust k8s manifest parsing

### DIFF
--- a/kardinal-cli/cmd/root.go
+++ b/kardinal-cli/cmd/root.go
@@ -257,6 +257,7 @@ func parseKubernetesManifestFile(kubernetesManifestFile string) ([]api_types.Ser
 	return finalServiceConfigs, nil
 }
 
+// Use in priority the label app value
 func getObjectName(obj *metav1.ObjectMeta) string {
 	labelApp, ok := obj.GetLabels()["app"]
 	if ok {

--- a/kardinal-cli/cmd/root.go
+++ b/kardinal-cli/cmd/root.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	projectName = "kardinal"
-	devMode     = true
+	devMode     = false
 
 	kontrolBaseURLTmpl                  = "%s://%s"
 	kontrolClusterResourcesEndpointTmpl = "%s/tenant/%s/cluster-resources"

--- a/kardinal-cli/cmd/root.go
+++ b/kardinal-cli/cmd/root.go
@@ -3,13 +3,15 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"kardinal.cli/consts"
-	"kardinal.cli/multi_os_cmd_executor"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"path"
 	"strings"
+
+	"kardinal.cli/consts"
+	"kardinal.cli/multi_os_cmd_executor"
 
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
@@ -27,7 +29,7 @@ import (
 
 const (
 	projectName = "kardinal"
-	devMode     = false
+	devMode     = true
 
 	kontrolBaseURLTmpl                  = "%s://%s"
 	kontrolClusterResourcesEndpointTmpl = "%s/tenant/%s/cluster-resources"
@@ -211,10 +213,7 @@ func parseKubernetesManifestFile(kubernetesManifestFile string) ([]api_types.Ser
 	manifest := string(fileBytes)
 	// TODO: Check format of manifest file
 	blocks := strings.Split(manifest, "---")
-	if len(blocks)%2 != 0 {
-		return nil, stacktrace.NewError("The manifest should contain pairs of service / deployment specifications")
-	}
-	serviceConfigs := make([]api_types.ServiceConfig, len(blocks)/2)
+	serviceConfigs := make([]api_types.ServiceConfig, int(math.Ceil(float64(len(blocks))/2)))
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	for index, spec := range strings.Split(manifest, "---") {
 		if len(spec) == 0 {
@@ -227,6 +226,7 @@ func parseKubernetesManifestFile(kubernetesManifestFile string) ([]api_types.Ser
 		switch obj := obj.(type) {
 		case *corev1.Service:
 			service := obj
+			fmt.Printf("Service annotations: %v\n", service.GetObjectMeta().GetAnnotations())
 			serviceConfigs[index/2].Service = *service
 		case *appv1.Deployment:
 			deployment := obj


### PR DESCRIPTION
- Support for service with no deployment e.g. load balancer service (ingress).
- Support for unordered service / deployment pairs.  Name matching uses the metadata label app string or the metadata name.

Example of manifest supported:
```
apiVersion: v1
kind: Service
metadata:
  labels:
    app: redis-prod
    version: v1
  name: redis-prod
  namespace: voting-app
  annotations:
    kardinal.dev.service/stateful: "true"
    kardinal.dev/plugins: |
      - name: github.com/kardinaldev/redis-db-sidecar-plugin:36ed9a4
        args:
          mode: "pass-through" 
spec:
  ports:
    - name: tcp-redis
      port: 6379
      protocol: TCP
      targetPort: 6379
  selector:
    app: redis-prod
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: redis-prod
    version: v1
  name: redis-prod-v1
  namespace: voting-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: redis-prod
      version: v1
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      annotations:
        sidecar.istio.io/inject: "true"
      labels:
        app: redis-prod
        version: v1
    spec:
      containers:
        - name: redis-prod
          image: bitnami/redis:6.0.8
          env:
            - name: ALLOW_EMPTY_PASSWORD
              value: "yes"
            - name: REDIS_PORT_NUMBER
              value: "6379"
          resources:
            requests:
              cpu: 100m
              memory: 128Mi
            limits:
              cpu: 250m
              memory: 256Mi
          ports:
            - containerPort: 6379
              name: redis

---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: voting-app-ui
    version: v1
  name: voting-app-ui
  namespace: voting-app
  annotations:
    kardinal.dev.service/dependencies: "redis-prod:6379"
spec:
  ports:
    - name: http
      port: 80
      protocol: TCP
      targetPort: 80
  selector:
    app: voting-app-ui
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: voting-app-ui
    version: v1
  name: voting-app-ui-v1
  namespace: voting-app
spec:
  replicas: 1
  selector:
    matchLabels:
      app: voting-app-ui
      version: v1
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      annotations:
        sidecar.istio.io/inject: "true"
      labels:
        app: voting-app-ui
        version: v1
    spec:
      containers:
        - name: voting-app-ui
          image: kurtosistech/demo-voting-app-ui
          imagePullPolicy: IfNotPresent
          resources:
            requests:
              cpu: 100m
              memory: 128Mi
            limits:
              cpu: 250m
              memory: 256Mi
          ports:
            - containerPort: 80
          env:
            - name: REDIS
              value: "redis-prod"
---
apiVersion: v1
kind: Service
metadata:
  name: voting-app-lb
  annotations:
    kardinal.dev.service/ingress: "true"
spec:
  type: LoadBalancer
  ports:
  - port: 80
  selector:
    app: voting-app-ui
```