### PR TITLE
chore: clean up no longer required CI skip check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,39 +15,13 @@ on:
     paths-ignore:
       - 'website/**'
 
+
 env:
   MAIN_BRANCH: ${{ 'refs/heads/main' }}
 
 jobs:
-  # Check if we should skip CI if only ./website directory was modified
-  check_skip_condition:
-    name: Check if CI should be skipped
-    runs-on: ubuntu-latest
-    outputs:
-      run_workflow: ${{ steps.check.outputs.run_workflow }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0  # fetches all history for all branches and tags
-      - name: Check for changes outside website directory
-        id: check
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            # On main branch, compare the latest commit with its parent
-            diff_base="HEAD^"
-          else
-            # On other branches or PRs, compare with the main branch
-            diff_base="origin/main"
-          fi
-          if git diff --name-only $diff_base HEAD | grep -v -e '^website/' | grep -q '^'; then
-            echo "run_workflow=true" >> $GITHUB_OUTPUT
-          else
-            echo "run_workflow=false" >> $GITHUB_OUTPUT
-          fi
   check_nix:
     name: Basic Check
-    needs: check_skip_condition
-    if: needs.check_skip_condition.outputs.run_workflow == 'true'
     runs-on: ubuntu-22.04
     steps:
       - name: git checkout
@@ -89,8 +63,7 @@ jobs:
 
   build_publish_images:
     name: Test, build and publish images
-    needs: [check_skip_condition, check_nix]
-    if: needs.check_skip_condition.outputs.run_workflow == 'true'
+    needs: check_nix
     runs-on: ubuntu-22.04
     steps:
       - name: git checkout
@@ -132,8 +105,7 @@ jobs:
 
   build_clis:
     name: Test and build cross-compiled clis
-    needs: [check_skip_condition, check_nix]
-    if: needs.check_skip_condition.outputs.run_workflow == 'true'
+    needs: check_nix
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [0.1.3](https://github.com/kurtosis-tech/kardinal/compare/0.1.2...0.1.3) (2024-07-12)
 
-
 ### Features
 
 * remove old urls ([#21](https://github.com/kurtosis-tech/kardinal/issues/21)) ([2ce038f](https://github.com/kurtosis-tech/kardinal/commit/2ce038f8e7fb16979998d88c84d871b76596197b))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [0.1.3](https://github.com/kurtosis-tech/kardinal/compare/0.1.2...0.1.3) (2024-07-12)
 
+
 ### Features
 
 * remove old urls ([#21](https://github.com/kurtosis-tech/kardinal/issues/21)) ([2ce038f](https://github.com/kurtosis-tech/kardinal/commit/2ce038f8e7fb16979998d88c84d871b76596197b))

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -158,11 +158,9 @@ br[data-mobile="true"] {
     background-position: 0% 0%;
   }
 }
-
 html {
   color-scheme: light;
 }
-
 /* Carousel styles */
 .carousel .control-prev.control-arrow:before {
   border-right: 16px solid rgb(255, 255, 255) !important;


### PR DESCRIPTION
the `paths-ignore` filter is enough to make CI skip on website, no need to also have this explicit check step