### PR TITLE
fix: remove extra space in CTA heading

### DIFF
--- a/website/components/CTASmall.tsx
+++ b/website/components/CTASmall.tsx
@@ -91,9 +91,6 @@ namespace S {
     }
   `;
   export const CTAHeading = styled(Heading.H2)`
-    em {
-      margin-left: 10px;
-    }
     img {
       width: 32px;
       height: 32px;


### PR DESCRIPTION
<img width="703" alt="image" src="https://github.com/user-attachments/assets/e15ee117-62fe-482f-81db-d7d8474ede8c">
