### PR TITLE
fix: fix cli installer for zsh and other shells

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,66 @@ jobs:
           ln -s $path $binout
           ls -lah $binout
           [ -s $binout ]
+
+  test_cli_install:
+    strategy:
+      matrix:
+        shell: [bash, fish, zsh]
+    runs-on: ubuntu-latest
+    steps:
+    - name: git checkout
+      uses: actions/checkout@v3
+
+    - name: Install ShellCheck and shells
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y shellcheck fish zsh
+
+    - name: Run ShellCheck
+      run: shellcheck ./scripts/install_cli.sh
+
+    - name: Run install script with ${{ matrix.shell }}
+      run: |
+        if [ "${{ matrix.shell }}" = "fish" ]; then
+          fish -c 'set -gx SHELL (which fish); cat ./scripts/install_cli.sh | bash'
+        elif [ "${{ matrix.shell }}" = "zsh" ]; then
+          zsh -c 'export SHELL=$(which zsh); cat ./scripts/install_cli.sh | bash'
+        elif [ "${{ matrix.shell }}" = "bash" ]; then
+          bash -c 'export SHELL=$(which bash); cat ./scripts/install_cli.sh | bash'
+        else
+          echo "Unsupported shell: ${{ matrix.shell }}"
+          exit 1
+        fi
+
+
+    - name: Check if ~/.local/bin exists
+      run: |
+        if [ ! -d ~/.local/bin ]; then
+          echo "~/.local/bin directory was not created"
+          exit 1
+        fi
+
+    - name: Check if config was added
+      run: |
+        if [ "${{ matrix.shell }}" = "fish" ]; then
+          config_file="$HOME/.config/fish/config.fish"
+        elif [ "${{ matrix.shell }}" = "zsh" ]; then
+          config_file="$HOME/.zshrc"
+        else
+          config_file="$HOME/.bashrc"
+        fi
+        if ! grep -q "# Kardinal CLI config" "$config_file"; then
+          echo "CLI tool configuration was not added to $config_file"
+          exit 1
+        fi
+
+    - name: Verify kardinal command
+      run: |
+        if [ "${{ matrix.shell }}" = "fish" ]; then
+          fish -c 'source ~/.config/fish/config.fish; if kardinal | grep -q "Kardinal CLI"; then exit 0; else exit 1; end'
+        elif [ "${{ matrix.shell }}" = "zsh" ]; then
+          zsh -c 'source ~/.zshrc; if kardinal | grep -q "Kardinal CLI"; then exit 0; else exit 1; fi'
+        else
+          bash -c 'source ~/.bashrc; if kardinal | grep -q "Kardinal CLI"; then exit 0; else exit 1; fi'
+        fi
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,14 @@ jobs:
     - name: Verify kardinal command
       run: |
         if [ "${{ matrix.shell }}" = "fish" ]; then
-          fish -c 'source ~/.config/fish/config.fish; if kardinal | grep -q "Kardinal CLI"; then exit 0; else exit 1; end'
+          fish -c '
+            source ~/.config/fish/config.fish
+            if kardinal | string match -q "*Kardinal CLI*"
+              exit 0
+            else
+              exit 1
+            end
+          '
         elif [ "${{ matrix.shell }}" = "zsh" ]; then
           zsh -c 'source ~/.zshrc; if kardinal | grep -q "Kardinal CLI"; then exit 0; else exit 1; fi'
         else

--- a/scripts/install_cli.sh
+++ b/scripts/install_cli.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -17,22 +17,20 @@ elif [[ "$ARCH" == "aarch64" ]]; then
 fi
 
 BIN_FOLDER="$HOME/.local/bin"
-mkdir -p $BIN_FOLDER
+mkdir -p "$BIN_FOLDER"
 
 LATEST_RELEASE=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
 echo "Downloading $BINARY_NAME $LATEST_RELEASE for $OS $ARCH..."
 DOWNLOAD_URL="https://github.com/$REPO/releases/download/$LATEST_RELEASE/${BINARY_NAME}-${OS}-${ARCH}"
-curl -L $DOWNLOAD_URL -o /$BIN_FOLDER/$BINARY_NAME
-chmod +x $BIN_FOLDER/$BINARY_NAME
+curl -L "$DOWNLOAD_URL" -o "$BIN_FOLDER/$BINARY_NAME"
+chmod +x "$BIN_FOLDER/$BINARY_NAME"
 
-USER_SHELL=$(basename $SHELL)
-echo "Detected shell: $USER_SHELL"
+USER_SHELL=$(basename "$SHELL")
 
 handle_error() {
 	local exit_code=$?
-	echo "Ops! Failed to setup integration with your $USER_SHELL shell. Please add the following lines to 
-  your shell configuration manually (changes may not be persistent)
+	echo "Ops! Failed to setup integration with your $USER_SHELL shell. Please add the following lines to your shell configuration manually (changes may not be persistent)
 export PATH=\$PATH:$BIN_FOLDER
 source <($BIN_FOLDER/$BINARY_NAME completion $USER_SHELL)"
 	exit $exit_code
@@ -40,24 +38,49 @@ source <($BIN_FOLDER/$BINARY_NAME completion $USER_SHELL)"
 
 trap 'handle_error' ERR
 
-if [ -f $BIN_FOLDER/$BINARY_NAME ]; then
-	if [ $USER_SHELL == 'bash' ]; then
-		echo "export PATH=\$PATH:$BIN_FOLDER" >>~/.bashrc
-		echo "source <($BIN_FOLDER/$BINARY_NAME completion bash)" >>~/.bashrc
-		source ~/.bashrc
-	fi
+# Patch the shell configuration file to include the kardinal binary and completion
+patch_shell_config() {
+  local user_shell_config_file
+  user_shell_config_file=''
+  echo "Detected shell: $USER_SHELL"
 
-	if [ $USER_SHELL == 'zsh' ]; then
-		echo "export PATH=\$PATH:$BIN_FOLDER" >>~/.zshrc
-		echo "source <($BIN_FOLDER/$BINARY_NAME completion zsh)" >>~/.bashrc
-		source ~/.zshrc
-	fi
+  # bash and zsh
+  common_shell_config() {
+    local config_content="
+# Kardinal CLI config
+export PATH=\$PATH:$BIN_FOLDER
+source <($BIN_FOLDER/$BINARY_NAME completion $USER_SHELL)
+"
+    echo "$config_content">>"$1"
+  }
 
-	if [ $USER_SHELL == 'fish' ]; then
-		echo "set -gx PATH \$PATH $BIN_FOLDER" >>~/.config/fish/config.fish
-		echo "source <($BIN_FOLDER/$BINARY_NAME completion fish)" >>~/.bashrc
-		source ~/.config/fish/config.fish
-	fi
-fi
+  if [ -f "$BIN_FOLDER/$BINARY_NAME" ]; then
+    if [ "$USER_SHELL" == 'bash' ]; then
+      # shellcheck disable=SC2088
+      user_shell_config_file=~/.bashrc
+      common_shell_config $user_shell_config_file
+    fi
 
-echo "$BINARY_NAME has been installed successfully!"
+    if [ "$USER_SHELL" == "zsh" ]; then
+      # shellcheck disable=SC2088
+      user_shell_config_file=~/.zshrc
+      common_shell_config $user_shell_config_file
+    fi
+
+    if [ "$USER_SHELL" == "fish" ]; then
+      # shellcheck disable=SC2088
+      user_shell_config_file=~/.config/fish/config.fish
+      local fish_config_content="
+# Kardinal CLI config
+set -gx PATH \$PATH $BIN_FOLDER
+kardinal completion fish | source
+"
+    echo "$fish_config_content">>"$user_shell_config_file"
+    fi
+  fi
+
+  echo "Kardinal CLI has been installed successfully!"
+  echo "Please reload your shell or 'source $user_shell_config_file' to start using kardinal"
+}
+
+patch_shell_config


### PR DESCRIPTION
currently the cli installer errors out if the user has any existing shell configuration in `~/.zshrc` for example. this is because we erroneously try to `source` their shell config in the install script, which runs in `/bin/sh`.

This addresses this issue by:
- updating the installer to ask the user to reload their shell or source their config file to use kardinal.
- adds a test in CI to ensure the installer works across shells
- runs `shellcheck` on the installer to ensure to common shell script blunders dont make it into the code