### PR TITLE
feat: add option to anonymously report install

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -83,8 +83,6 @@ github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
-github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d h1:uGg2frlt3IcT7kbV6LEp5ONv4vmoO2FW4qSO+my/aoM=
@@ -131,6 +129,8 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/schollz/closestmatch v2.1.0+incompatible h1:Uel2GXEpJqOWBrlyI+oY9LTiyyjYS17cCYRqP13/SHk=
 github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
+github.com/segmentio/conf v1.2.0 h1:5OT9+6OyVHLsFLsiJa/2KlqiA1m7mpdUBlkB/qYTMts=
+github.com/segmentio/conf v1.2.0/go.mod h1:Y3B9O/PqqWqjyxyWWseyj/quPEtMu1zDp/kVbSWWaB0=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad h1:fiWzISvDn0Csy5H0iwgAuJGQTUpVfEMJJd4nRFXogbc=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=

--- a/kardinal-cli/go.mod
+++ b/kardinal-cli/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.5.0
 	github.com/kurtosis-tech/stacktrace v0.0.0-20211028211901-1c67a77b5409
 	github.com/samber/lo v1.46.0
+	github.com/segmentio/analytics-go/v3 v3.3.0
 	github.com/spf13/cobra v1.8.0
 	k8s.io/api v0.30.2
 	k8s.io/apimachinery v0.30.2
@@ -17,6 +18,7 @@ require (
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
@@ -37,6 +39,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/oapi-codegen/runtime v1.1.1 // indirect
+	github.com/segmentio/backo-go v1.0.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/term v0.20.0 // indirect

--- a/kardinal-cli/go.sum
+++ b/kardinal-cli/go.sum
@@ -6,6 +6,8 @@ github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -95,6 +97,10 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.46.0 h1:w8G+oaCPgz1PoCJztqymCFaKwXt+5cCXn51uPxExFfQ=
 github.com/samber/lo v1.46.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
+github.com/segmentio/analytics-go/v3 v3.3.0 h1:8VOMaVGBW03pdBrj1CMFfY9o/rnjJC+1wyQHlVxjw5o=
+github.com/segmentio/analytics-go/v3 v3.3.0/go.mod h1:p8owAF8X+5o27jmvUognuXxdtqvSGtD0ZrfY2kcS9bE=
+github.com/segmentio/backo-go v1.0.0 h1:kbOAtGJY2DqOR0jfRkYEorx/b18RgtepGtY3+Cpe6qA=
+github.com/segmentio/backo-go v1.0.0/go.mod h1:kJ9mm9YmoWSkk+oQ+5Cj8DEoRCX2JT6As4kEtIIOp1M=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=

--- a/kardinal-cli/gomod2nix.toml
+++ b/kardinal-cli/gomod2nix.toml
@@ -52,6 +52,9 @@ schema = 3
   [mod."github.com/bmatcuk/doublestar"]
     version = "v1.1.1"
     hash = "sha256-mcR+gZ11pja98RwW7eN6T6TwC07ujPmQ8CcyH45r//0="
+  [mod."github.com/bmizerany/assert"]
+    version = "v0.0.0-20160611221934-b7ed37b82869"
+    hash = "sha256-WnAmAW0f97kZoGhBmIGNBjblTh02O9WfPrH9RD0PHqI="
   [mod."github.com/bsm/ginkgo/v2"]
     version = "v2.12.0"
     hash = "sha256-rZ9AF2RPWwQcgFmh3bmUXDaTLL14fQfPtv+DuC8xqzQ="
@@ -364,6 +367,15 @@ schema = 3
   [mod."github.com/schollz/closestmatch"]
     version = "v2.1.0+incompatible"
     hash = "sha256-SpWqGfqlMkZPQ6TSf7NTaYMbQllBaBgPM8oxTBOTn7w="
+  [mod."github.com/segmentio/analytics-go/v3"]
+    version = "v3.3.0"
+    hash = "sha256-4uaqp8P59nvmihaLwJFBBCFREjHe1q969plWS8qIyHw="
+  [mod."github.com/segmentio/backo-go"]
+    version = "v1.0.0"
+    hash = "sha256-zeabw/evmjj+0Enxug+KzvJQk2LFXz8Yd3t1mJ1YHyI="
+  [mod."github.com/segmentio/conf"]
+    version = "v1.2.0"
+    hash = "sha256-eInV5kwGAToAkh+rQcVatK768cbciEcgo7/k3o7bvYA="
   [mod."github.com/sirupsen/logrus"]
     version = "v1.9.3"
     hash = "sha256-EnxsWdEUPYid+aZ9H4/iMTs1XMvCLbXZRDyvj89Ebms="

--- a/kardinal-manager/gomod2nix.toml
+++ b/kardinal-manager/gomod2nix.toml
@@ -364,6 +364,15 @@ schema = 3
   [mod."github.com/schollz/closestmatch"]
     version = "v2.1.0+incompatible"
     hash = "sha256-SpWqGfqlMkZPQ6TSf7NTaYMbQllBaBgPM8oxTBOTn7w="
+  [mod."github.com/segmentio/analytics-go/v3"]
+    version = "v3.3.0"
+    hash = "sha256-4uaqp8P59nvmihaLwJFBBCFREjHe1q969plWS8qIyHw="
+  [mod."github.com/segmentio/backo-go"]
+    version = "v1.0.0"
+    hash = "sha256-zeabw/evmjj+0Enxug+KzvJQk2LFXz8Yd3t1mJ1YHyI="
+  [mod."github.com/segmentio/conf"]
+    version = "v1.2.0"
+    hash = "sha256-eInV5kwGAToAkh+rQcVatK768cbciEcgo7/k3o7bvYA="
   [mod."github.com/sirupsen/logrus"]
     version = "v1.9.3"
     hash = "sha256-EnxsWdEUPYid+aZ9H4/iMTs1XMvCLbXZRDyvj89Ebms="

--- a/libs/cli-kontrol-api/gomod2nix.toml
+++ b/libs/cli-kontrol-api/gomod2nix.toml
@@ -364,6 +364,15 @@ schema = 3
   [mod."github.com/schollz/closestmatch"]
     version = "v2.1.0+incompatible"
     hash = "sha256-SpWqGfqlMkZPQ6TSf7NTaYMbQllBaBgPM8oxTBOTn7w="
+  [mod."github.com/segmentio/analytics-go/v3"]
+    version = "v3.3.0"
+    hash = "sha256-4uaqp8P59nvmihaLwJFBBCFREjHe1q969plWS8qIyHw="
+  [mod."github.com/segmentio/backo-go"]
+    version = "v1.0.0"
+    hash = "sha256-zeabw/evmjj+0Enxug+KzvJQk2LFXz8Yd3t1mJ1YHyI="
+  [mod."github.com/segmentio/conf"]
+    version = "v1.2.0"
+    hash = "sha256-eInV5kwGAToAkh+rQcVatK768cbciEcgo7/k3o7bvYA="
   [mod."github.com/sirupsen/logrus"]
     version = "v1.9.3"
     hash = "sha256-EnxsWdEUPYid+aZ9H4/iMTs1XMvCLbXZRDyvj89Ebms="

--- a/libs/manager-kontrol-api/gomod2nix.toml
+++ b/libs/manager-kontrol-api/gomod2nix.toml
@@ -364,6 +364,15 @@ schema = 3
   [mod."github.com/schollz/closestmatch"]
     version = "v2.1.0+incompatible"
     hash = "sha256-SpWqGfqlMkZPQ6TSf7NTaYMbQllBaBgPM8oxTBOTn7w="
+  [mod."github.com/segmentio/analytics-go/v3"]
+    version = "v3.3.0"
+    hash = "sha256-4uaqp8P59nvmihaLwJFBBCFREjHe1q969plWS8qIyHw="
+  [mod."github.com/segmentio/backo-go"]
+    version = "v1.0.0"
+    hash = "sha256-zeabw/evmjj+0Enxug+KzvJQk2LFXz8Yd3t1mJ1YHyI="
+  [mod."github.com/segmentio/conf"]
+    version = "v1.2.0"
+    hash = "sha256-eInV5kwGAToAkh+rQcVatK768cbciEcgo7/k3o7bvYA="
   [mod."github.com/sirupsen/logrus"]
     version = "v1.9.3"
     hash = "sha256-EnxsWdEUPYid+aZ9H4/iMTs1XMvCLbXZRDyvj89Ebms="

--- a/scripts/install_cli.sh
+++ b/scripts/install_cli.sh
@@ -42,6 +42,60 @@ chmod +x "$BIN_FOLDER/$BINARY_NAME"
 PARENT_SHELL=$(ps -o comm= -p $PPID)
 echo "Detected parent shell: $PARENT_SHELL"
 
+# There are simpler interactive checks such as checking $PS1 or $-,
+# but since we are piping the script to sh, these methods don't work
+is_interactive_shell() {
+  # Check if stdin is a terminal
+  if [ -t 0 ]; then
+    return 0
+  fi
+  # Check if stdout is a terminal
+  if [ -t 1 ]; then
+    return 0
+  fi
+  # Additional check: see if we can read from /dev/tty
+  if [ -t 2 ] && [ -r /dev/tty ]; then
+    return 0
+  fi
+  return 1
+}
+
+
+# Function to prompt user with Y/n question
+prompt_user() {
+  prompt="$1 [Y/n] "
+  if is_interactive_shell; then
+    # Use /dev/tty to read input if available
+    if [ -r /dev/tty ]; then
+      printf "%s" "$prompt" > /dev/tty
+      read -r answer < /dev/tty
+    else
+      printf "%s" "$prompt"
+      read -r answer
+    fi
+  else
+    # No terminal available, use a sensible default
+    answer="N"
+  fi
+
+  case "$answer" in
+    [Nn]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+post_install_questions() {
+  if is_interactive_shell; then
+    if prompt_user "Would you like to help us improve Kardinal by anonymously reporting your install?"; then
+      "$BIN_FOLDER/$BINARY_NAME" report-install
+    else
+      echo "No problem! Consider giving us a ⭐ on github to help us grow 😊"
+    fi
+  else
+    echo "Non-interactive shell detected. Skipping post-install questions."
+  fi
+}
+
 if [ -f "$BIN_FOLDER/$BINARY_NAME" ]; then
 	if [ $WAS_INTALLED_BEFORE -eq 0 ]; then
 		case "$PARENT_SHELL" in
@@ -76,13 +130,15 @@ if [ -f "$BIN_FOLDER/$BINARY_NAME" ]; then
 			;;
 		esac
 		echo "$BINARY_NAME has been installed successfully!"
-		echo "Run the following command to load Kardinal in the current shell (new shell will already load it):"
+		echo "Run the following command to load Kardinal in the current shell (new shells will already load it):"
 		echo ""
 		echo "> source $CONFIG_FILE"
 		echo ""
+    post_install_questions
 	else
 		echo "Kardinal was installed before, just updated it."
 		echo ""
+    post_install_questions
 	fi
 else
 	echo "Failed to install $BINARY_NAME. Please try again."

--- a/scripts/install_cli.sh
+++ b/scripts/install_cli.sh
@@ -142,7 +142,6 @@ if [ -f "$BIN_FOLDER/$BINARY_NAME" ]; then
 	else
 		echo "Kardinal was installed before, just updated it."
 		echo ""
-    post_install_questions
 	fi
 else
 	echo "Failed to install $BINARY_NAME. Please try again."

--- a/scripts/install_cli.sh
+++ b/scripts/install_cli.sh
@@ -85,6 +85,10 @@ prompt_user() {
 }
 
 post_install_questions() {
+  # Optionally skip post-install questions and analytics, used in the playground
+  if [ -n "$SKIP_KARDINAL_POST_INSTALL" ]; then
+    return 0
+  fi
   if is_interactive_shell; then
     if prompt_user "Would you like to help us improve Kardinal by anonymously reporting your install?"; then
       "$BIN_FOLDER/$BINARY_NAME" report-install

--- a/sidecars/redis-overlay-service/gomod2nix.toml
+++ b/sidecars/redis-overlay-service/gomod2nix.toml
@@ -52,6 +52,9 @@ schema = 3
   [mod."github.com/bmatcuk/doublestar"]
     version = "v1.1.1"
     hash = "sha256-mcR+gZ11pja98RwW7eN6T6TwC07ujPmQ8CcyH45r//0="
+  [mod."github.com/bmizerany/assert"]
+    version = "v0.0.0-20160611221934-b7ed37b82869"
+    hash = "sha256-WnAmAW0f97kZoGhBmIGNBjblTh02O9WfPrH9RD0PHqI="
   [mod."github.com/bsm/ginkgo/v2"]
     version = "v2.12.0"
     hash = "sha256-rZ9AF2RPWwQcgFmh3bmUXDaTLL14fQfPtv+DuC8xqzQ="
@@ -364,6 +367,15 @@ schema = 3
   [mod."github.com/schollz/closestmatch"]
     version = "v2.1.0+incompatible"
     hash = "sha256-SpWqGfqlMkZPQ6TSf7NTaYMbQllBaBgPM8oxTBOTn7w="
+  [mod."github.com/segmentio/analytics-go/v3"]
+    version = "v3.3.0"
+    hash = "sha256-4uaqp8P59nvmihaLwJFBBCFREjHe1q969plWS8qIyHw="
+  [mod."github.com/segmentio/backo-go"]
+    version = "v1.0.0"
+    hash = "sha256-zeabw/evmjj+0Enxug+KzvJQk2LFXz8Yd3t1mJ1YHyI="
+  [mod."github.com/segmentio/conf"]
+    version = "v1.2.0"
+    hash = "sha256-eInV5kwGAToAkh+rQcVatK768cbciEcgo7/k3o7bvYA="
   [mod."github.com/sirupsen/logrus"]
     version = "v1.9.3"
     hash = "sha256-EnxsWdEUPYid+aZ9H4/iMTs1XMvCLbXZRDyvj89Ebms="


### PR DESCRIPTION
- Allow users to opt-in to anonymously reporting an install of kardinal cli

TODO:
- [x] ~~Skip this prompt in the playground so those installs dont count as a real install. We already have a separate event that we can track to know how many people are using the playground, so no need to use this method.~~ Implemented in https://github.com/kurtosis-tech/kardinal-playground/pull/34


Example output for opt-in: 

```
﻿﻿# ... rest of installer script output
﻿﻿Would you like to help us improve Kardinal by anonymously reporting your install? [Y/n] y
﻿﻿2024/08/09 13:37:33 Thank you for helping us improve Kardinal! 🧡
```

Example output for opt-out:

```
Would you like to help us improve Kardinal by anonymously reporting your install? [Y/n] n
No problem! Consider giving us a ⭐ on github to help us grow 😊
```