### PR TITLE
fix: dont hide the nav on docs

### DIFF
--- a/website/components/Nav/index.tsx
+++ b/website/components/Nav/index.tsx
@@ -114,7 +114,7 @@ const Nav = () => {
         <S.MobileNavButton onClick={toggleNav}>
           {isNavOpen ? <BiX size={24} /> : <BiMenu size={24} />}
         </S.MobileNavButton>
-        {!isDocs && <NavLinksAndButton />}
+        <NavLinksAndButton />
       </S.Container>
     </S.Nav>
   );


### PR DESCRIPTION
this check was a mistake, we do want to show the nav on the docs