### PR TITLE
feat: adding the cluster resources manifest endpoint in Kontrol API spec and bindings

### DIFF
--- a/libs/manager-kontrol-api/api/golang/client/client.gen.go
+++ b/libs/manager-kontrol-api/api/golang/client/client.gen.go
@@ -12,6 +12,8 @@ import (
 	"net/url"
 	"strings"
 
+	"gopkg.in/yaml.v2"
+
 	. "github.com/kurtosis-tech/kardinal/libs/manager-kontrol-api/api/golang/types"
 	"github.com/oapi-codegen/runtime"
 )
@@ -91,10 +93,25 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 type ClientInterface interface {
 	// GetTenantUuidClusterResources request
 	GetTenantUuidClusterResources(ctx context.Context, uuid Uuid, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetTenantUuidClusterResourcesManifest request
+	GetTenantUuidClusterResourcesManifest(ctx context.Context, uuid Uuid, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) GetTenantUuidClusterResources(ctx context.Context, uuid Uuid, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetTenantUuidClusterResourcesRequest(c.Server, uuid)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetTenantUuidClusterResourcesManifest(ctx context.Context, uuid Uuid, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetTenantUuidClusterResourcesManifestRequest(c.Server, uuid)
 	if err != nil {
 		return nil, err
 	}
@@ -122,6 +139,40 @@ func NewGetTenantUuidClusterResourcesRequest(server string, uuid Uuid) (*http.Re
 	}
 
 	operationPath := fmt.Sprintf("/tenant/%s/cluster-resources", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetTenantUuidClusterResourcesManifestRequest generates requests for GetTenantUuidClusterResourcesManifest
+func NewGetTenantUuidClusterResourcesManifestRequest(server string, uuid Uuid) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "uuid", runtime.ParamLocationPath, uuid)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/tenant/%s/cluster-resources/manifest", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -184,6 +235,9 @@ func WithBaseURL(baseURL string) ClientOption {
 type ClientWithResponsesInterface interface {
 	// GetTenantUuidClusterResourcesWithResponse request
 	GetTenantUuidClusterResourcesWithResponse(ctx context.Context, uuid Uuid, reqEditors ...RequestEditorFn) (*GetTenantUuidClusterResourcesResponse, error)
+
+	// GetTenantUuidClusterResourcesManifestWithResponse request
+	GetTenantUuidClusterResourcesManifestWithResponse(ctx context.Context, uuid Uuid, reqEditors ...RequestEditorFn) (*GetTenantUuidClusterResourcesManifestResponse, error)
 }
 
 type GetTenantUuidClusterResourcesResponse struct {
@@ -209,6 +263,29 @@ func (r GetTenantUuidClusterResourcesResponse) StatusCode() int {
 	return 0
 }
 
+type GetTenantUuidClusterResourcesManifestResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	YAML200      *string
+	JSONDefault  *NotOk
+}
+
+// Status returns HTTPResponse.Status
+func (r GetTenantUuidClusterResourcesManifestResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetTenantUuidClusterResourcesManifestResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 // GetTenantUuidClusterResourcesWithResponse request returning *GetTenantUuidClusterResourcesResponse
 func (c *ClientWithResponses) GetTenantUuidClusterResourcesWithResponse(ctx context.Context, uuid Uuid, reqEditors ...RequestEditorFn) (*GetTenantUuidClusterResourcesResponse, error) {
 	rsp, err := c.GetTenantUuidClusterResources(ctx, uuid, reqEditors...)
@@ -216,6 +293,15 @@ func (c *ClientWithResponses) GetTenantUuidClusterResourcesWithResponse(ctx cont
 		return nil, err
 	}
 	return ParseGetTenantUuidClusterResourcesResponse(rsp)
+}
+
+// GetTenantUuidClusterResourcesManifestWithResponse request returning *GetTenantUuidClusterResourcesManifestResponse
+func (c *ClientWithResponses) GetTenantUuidClusterResourcesManifestWithResponse(ctx context.Context, uuid Uuid, reqEditors ...RequestEditorFn) (*GetTenantUuidClusterResourcesManifestResponse, error) {
+	rsp, err := c.GetTenantUuidClusterResourcesManifest(ctx, uuid, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetTenantUuidClusterResourcesManifestResponse(rsp)
 }
 
 // ParseGetTenantUuidClusterResourcesResponse parses an HTTP response from a GetTenantUuidClusterResourcesWithResponse call
@@ -245,6 +331,39 @@ func ParseGetTenantUuidClusterResourcesResponse(rsp *http.Response) (*GetTenantU
 			return nil, err
 		}
 		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetTenantUuidClusterResourcesManifestResponse parses an HTTP response from a GetTenantUuidClusterResourcesManifestWithResponse call
+func ParseGetTenantUuidClusterResourcesManifestResponse(rsp *http.Response) (*GetTenantUuidClusterResourcesManifestResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetTenantUuidClusterResourcesManifestResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest NotOk
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "yaml") && rsp.StatusCode == 200:
+		var dest string
+		if err := yaml.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.YAML200 = &dest
 
 	}
 

--- a/libs/manager-kontrol-api/api/golang/server/server.gen.go
+++ b/libs/manager-kontrol-api/api/golang/server/server.gen.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -27,6 +28,9 @@ type ServerInterface interface {
 	// Cluster resource definition
 	// (GET /tenant/{uuid}/cluster-resources)
 	GetTenantUuidClusterResources(ctx echo.Context, uuid Uuid) error
+	// Cluster resource definition in a manifest YAML response
+	// (GET /tenant/{uuid}/cluster-resources/manifest)
+	GetTenantUuidClusterResourcesManifest(ctx echo.Context, uuid Uuid) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -47,6 +51,22 @@ func (w *ServerInterfaceWrapper) GetTenantUuidClusterResources(ctx echo.Context)
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.GetTenantUuidClusterResources(ctx, uuid)
+	return err
+}
+
+// GetTenantUuidClusterResourcesManifest converts echo context to params.
+func (w *ServerInterfaceWrapper) GetTenantUuidClusterResourcesManifest(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "uuid" -------------
+	var uuid Uuid
+
+	err = runtime.BindStyledParameterWithOptions("simple", "uuid", ctx.Param("uuid"), &uuid, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter uuid: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetTenantUuidClusterResourcesManifest(ctx, uuid)
 	return err
 }
 
@@ -79,6 +99,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	}
 
 	router.GET(baseURL+"/tenant/:uuid/cluster-resources", wrapper.GetTenantUuidClusterResources)
+	router.GET(baseURL+"/tenant/:uuid/cluster-resources/manifest", wrapper.GetTenantUuidClusterResourcesManifest)
 
 }
 
@@ -113,11 +134,53 @@ func (response GetTenantUuidClusterResourcesdefaultJSONResponse) VisitGetTenantU
 	return json.NewEncoder(w).Encode(response.Body)
 }
 
+type GetTenantUuidClusterResourcesManifestRequestObject struct {
+	Uuid Uuid `json:"uuid"`
+}
+
+type GetTenantUuidClusterResourcesManifestResponseObject interface {
+	VisitGetTenantUuidClusterResourcesManifestResponse(w http.ResponseWriter) error
+}
+
+type GetTenantUuidClusterResourcesManifest200ApplicationxYamlResponse struct {
+	Body          io.Reader
+	ContentLength int64
+}
+
+func (response GetTenantUuidClusterResourcesManifest200ApplicationxYamlResponse) VisitGetTenantUuidClusterResourcesManifestResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/x-yaml")
+	if response.ContentLength != 0 {
+		w.Header().Set("Content-Length", fmt.Sprint(response.ContentLength))
+	}
+	w.WriteHeader(200)
+
+	if closer, ok := response.Body.(io.ReadCloser); ok {
+		defer closer.Close()
+	}
+	_, err := io.Copy(w, response.Body)
+	return err
+}
+
+type GetTenantUuidClusterResourcesManifestdefaultJSONResponse struct {
+	Body       ResponseInfo
+	StatusCode int
+}
+
+func (response GetTenantUuidClusterResourcesManifestdefaultJSONResponse) VisitGetTenantUuidClusterResourcesManifestResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.StatusCode)
+
+	return json.NewEncoder(w).Encode(response.Body)
+}
+
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
 	// Cluster resource definition
 	// (GET /tenant/{uuid}/cluster-resources)
 	GetTenantUuidClusterResources(ctx context.Context, request GetTenantUuidClusterResourcesRequestObject) (GetTenantUuidClusterResourcesResponseObject, error)
+	// Cluster resource definition in a manifest YAML response
+	// (GET /tenant/{uuid}/cluster-resources/manifest)
+	GetTenantUuidClusterResourcesManifest(ctx context.Context, request GetTenantUuidClusterResourcesManifestRequestObject) (GetTenantUuidClusterResourcesManifestResponseObject, error)
 }
 
 type StrictHandlerFunc = strictecho.StrictEchoHandlerFunc
@@ -157,22 +220,49 @@ func (sh *strictHandler) GetTenantUuidClusterResources(ctx echo.Context, uuid Uu
 	return nil
 }
 
+// GetTenantUuidClusterResourcesManifest operation middleware
+func (sh *strictHandler) GetTenantUuidClusterResourcesManifest(ctx echo.Context, uuid Uuid) error {
+	var request GetTenantUuidClusterResourcesManifestRequestObject
+
+	request.Uuid = uuid
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetTenantUuidClusterResourcesManifest(ctx.Request().Context(), request.(GetTenantUuidClusterResourcesManifestRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetTenantUuidClusterResourcesManifest")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(GetTenantUuidClusterResourcesManifestResponseObject); ok {
+		return validResponse.VisitGetTenantUuidClusterResourcesManifestResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8RWTXPbNhD9K5ptj5RgxZcOb5468Wg6tTOK3R4yHg8CraiNSQBdLJSwHv73DgjqI7Ek",
-	"+9A2J4Lct4u3D9A+PYFxjXcWrQQon8Br1g0Kcv8WIy3Sc4HBMHkhZ6GEu7vZ5cgtR7LCEWNwkQ1CAZRi",
-	"XssKCrC6QShzfgGMf0ViXEApHLGAYFbY6FRYWp9wQZhsBV3XJXDwzgbsCVw7uXlMC+OsoJW01N7XZHQi",
-	"oz6HxOhpr+LPjEso4Se160vlaFDzofTMLl3e7LvGLH71aAQXI2R2DAkyJKfav9YxCPJ86DkLxs4jC+U3",
-	"HWXlmP7u2T14V5MZIiTY9Iuv48qNh77X008oejq52E97n7JaKHbIMTXecd/8IOyQCEUWvAQKQm5CTpma",
-	"0Mq4cso/Vkp7CiqgiUzSqk1WamtgoJl1C70SvnZts7kHB+lq78N6OrncQk+TzPAdx8dfQmKoPakUUutj",
-	"TIKQzQpyrE/Kp2u/0ueTy13KPNb4knY563XiWZQvjh/JVmqbeIg12rVrH5ZUb347pxm/TfB3PfpHsK20",
-	"4BfdHqV3NcT/B2oBeU3mxCkbx7ieTj5k3GlKGXvwyqXQsSu3Jpao64cXuWwF+iNnvIrUf3GEuw/u02c0",
-	"krr4Zrw9G03GLTA9l44bLWk4k5XzN7AtRFawQk6VGgxBV3hgQm/Qrxu0twmbh/rGAT7mArs9iszs/kRD",
-	"t8OWaGOTKrydz2/mUMDs+t0NFPDnxfx6dn21V2LfT2hQQ0jqFPtdW10hq9+cFXb16OL9DApYI4dsAtPJ",
-	"2eQs7e48Wu0JSjjvP+XT67VUglZbUU/J4Dplsi+Med8YKuzvQDqCfjDNFlDCFcptn3oXafHMTopv7Pfj",
-	"YY13ENXba3f/nWe+OTv71xzzGcUDrvkhGoMhLGM92vDIY3ypYy3HdthSVtnj+1EQm0ZzC+XGabd/L0YL",
-	"XJKlfscCRFdJH3iu+33Xdd0/AQAA//8hn+431AgAAA==",
+	"H4sIAAAAAAAC/8RW32/bNhD+VwRuj7IZNy+D34KlDYwuSeEmG4YiCBj5JF9Dkdzx6EYL/L8PFCXLaWwn",
+	"A7bmST/u13cfT/fpURS2dtaAYS+mj8IpUjUwUPsUAi7idQG+IHSM1oipuL6enWa2zHgJGYG3gQoQucBo",
+	"c4qXIhdG1SCmKT4XBH8FJFiIKVOAXPhiCbWKiblx0c8zoanEer2Ozt5Z46EFcGH58j7eFNYwGI63yjmN",
+	"hYpg5FcfET1uZfyZoBRT8ZMc+pLJ6uW8Sz0zpU3FvmvMwIODgmGRAZElEV264Jj7Vx08A827nhNhZB0Q",
+	"Y3pSgZeW8O8W3a2zGovOggx1e/Mwquyo63s1uQNWk/HJdtinGNWIfPAcYe0stc13xHaBIk+ETwV6RjtG",
+	"KwuNYHhUWenuK6kceumhCITcyD4qttUhUESqES0TTtum7udgJ1zlnF9Nxqcb18Mgk/uA8f4XHxEqhzKa",
+	"5GofEs9oEoMU9EH6lHZLdTw+HULmQcNL3KWo15FngL9ZukdTyU3gLtRgVra5LVH3385hxO+j+4fW+y3Q",
+	"Vorhm2r2wjvr7D8AmgdaYXHglAtLsJqMPye/w5CS786Ri6Z9I7dC4qD07YtYNgT9niJeBer/OMLhhb37",
+	"CgXHLp6st2erqbALiNfSUq04Lmc0fPxObBKhYaiAYqYavFcV7NjQvffrFu1V9E1LvVeALynBUCNPyG4O",
+	"NHTVlQQT6pjh/Xx+ORe5mF18uBS5+ONkfjG7ONtKsa0n2LHByDrazpVRFZD8aA2T1dnJp5nIxQrIJxGY",
+	"jI/GR7G6dWCUQzEVx+2rdHotl5LBKMPyMQrcWhZJF0a0LQwVtDMQj6BdTLOFmIoz4Ks29Drg4pmc5E/k",
+	"98tujgcX2crr+uY7zXx3dPSfKeYziDtU83MoCvC+DDrrcaQ1XqqgeV+FDWSZNL5dBaGuFTVi2ivt5vci",
+	"W0CJBtuKuWBVRX7Ec95vYpqXTkfWymAJnreO6WlLV0v0GZiFs2g4I+BAxmdK6/af52O4AzLA4Ad8paXW",
+	"1hXL2DqrbdVkaDJrIKuDZtxAyHoEA2P5v5mU876BHzExD6NG1frpzOz4zt50KCLNamD1z5Pz37ap3T8w",
+	"udgMw816vV7/EwAA//8hLsi2EAsAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/libs/manager-kontrol-api/api/typescript/client/types.d.ts
+++ b/libs/manager-kontrol-api/api/typescript/client/types.d.ts
@@ -24,6 +24,28 @@ export interface paths {
       };
     };
   };
+  "/tenant/{uuid}/cluster-resources/manifest": {
+    /**
+     * Cluster resource definition in a manifest YAML response
+     * @description This endpoint returns all the Kubernetes resource for the cluster topology in one multi-resource manifest response
+     */
+    get: {
+      parameters: {
+        path: {
+          uuid: components["parameters"]["uuid"];
+        };
+      };
+      responses: {
+        /** @description Successful response */
+        200: {
+          content: {
+            "application/x-yaml": string;
+          };
+        };
+        default: components["responses"]["NotOk"];
+      };
+    };
+  };
 }
 
 export type webhooks = Record<string, never>;

--- a/libs/manager-kontrol-api/specs/api.yaml
+++ b/libs/manager-kontrol-api/specs/api.yaml
@@ -13,12 +13,31 @@ paths:
       responses:
         default:
           $ref: "#/components/responses/NotOk"
-        "200":
+        '200':
           description: Successful response
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ClusterResources"
+
+  /tenant/{uuid}/cluster-resources/manifest:
+    get:
+      tags:
+        - cluster-resources
+        - manifest
+      summary: Cluster resource definition in a manifest YAML response
+      description: This endpoint returns all the Kubernetes resource for the cluster topology in one multi-resource manifest response
+      parameters:
+        - $ref: "#/components/parameters/uuid"
+      responses:
+        default:
+          $ref: "#/components/responses/NotOk"
+        '200':
+          description: Successful response
+          content:
+            application/x-yaml:
+              schema:
+                type: string
 
 components:
   parameters:


### PR DESCRIPTION
This new endpoint will return the cluster topology in a YAML multi-resource manifest response.