### PR TITLE
fix: Exit with code 1 upon errors in the CLI

### DIFF
--- a/kardinal-cli/main.go
+++ b/kardinal-cli/main.go
@@ -1,10 +1,16 @@
 package main
 
-import "kardinal.cli/cmd"
+import (
+	"fmt"
+	"os"
+
+	"kardinal.cli/cmd"
+)
 
 func main() {
 
 	if err := cmd.Execute(); err != nil {
-		println("Error:", err.Error())
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
The CLI exits with 0 even after errors.  This is an issue for scripting.  This change fixes that.