### PR TITLE
fix: Handle gateway case where the baseline is missing or not labelled

### DIFF
--- a/kardinal-cli/cmd/root.go
+++ b/kardinal-cli/cmd/root.go
@@ -569,7 +569,7 @@ var gatewayCmd = &cobra.Command{
 		}
 
 		if err := deployment.StartGateway(ctx, hostFlowIdMap); err != nil {
-			log.Fatal("An error occurred while creating a gateway", err)
+			log.Fatalf("An error occurred while creating a gateway: %v", err)
 		}
 	},
 }

--- a/kardinal-manager/kardinal-manager/cluster_manager/cluster_manager.go
+++ b/kardinal-manager/kardinal-manager/cluster_manager/cluster_manager.go
@@ -386,7 +386,11 @@ func (manager *ClusterManager) ensureNamespace(ctx context.Context, name string)
 		value, found := existingNamespace.Labels[istioLabel]
 		if !found || value != enabledIstioValue {
 			existingNamespace.Labels[istioLabel] = enabledIstioValue
-			manager.kubernetesClient.clientSet.CoreV1().Namespaces().Update(ctx, existingNamespace, globalUpdateOptions)
+			existingNamespace.Labels[kardinalLabelKey] = enabledKardinal
+			_, err = manager.kubernetesClient.clientSet.CoreV1().Namespaces().Update(ctx, existingNamespace, globalUpdateOptions)
+			if err != nil {
+				return stacktrace.Propagate(err, "Failed to update Namespace: %s", name)
+			}
 		}
 	} else {
 		newNamespace := corev1.Namespace{


### PR DESCRIPTION
The CLI gateway command crashes if there is no baseline namespace.  The baseline namespace does not get labelled properly if it already exists.  This change fixes those issues.