### PR TITLE
fix: Do not alter the istio-system namespace

### DIFF
--- a/kardinal-manager/kardinal-manager/cluster_manager/cluster_manager.go
+++ b/kardinal-manager/kardinal-manager/cluster_manager/cluster_manager.go
@@ -22,6 +22,7 @@ const (
 	istioLabel                              = "istio-injection"
 	enabledIstioValue                       = "enabled"
 	telepresenceRestartedAtAnnotation       = "telepresence.getambassador.io/restartedAt"
+	istioSystemNamespace                    = "istio-system"
 
 	// TODO move these values to a shared library between Kardinal Manager, Kontrol and Kardinal CLI
 	kardinalLabelKey = "kardinal.dev"
@@ -381,16 +382,25 @@ func (manager *ClusterManager) CleanUpClusterResources(ctx context.Context, clus
 
 func (manager *ClusterManager) ensureNamespace(ctx context.Context, name string) error {
 
+	if name == istioSystemNamespace {
+		// Some resources might be under the istio system namespace but we don't want to alter
+		// this namespace because it is managed by Istio
+		return nil
+	}
+
 	existingNamespace, err := manager.kubernetesClient.clientSet.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
 	if err == nil && existingNamespace != nil {
 		value, found := existingNamespace.Labels[istioLabel]
 		if !found || value != enabledIstioValue {
 			existingNamespace.Labels[istioLabel] = enabledIstioValue
+		}
+		value, found = existingNamespace.Labels[kardinalLabelKey]
+		if !found || value != enabledKardinal {
 			existingNamespace.Labels[kardinalLabelKey] = enabledKardinal
-			_, err = manager.kubernetesClient.clientSet.CoreV1().Namespaces().Update(ctx, existingNamespace, globalUpdateOptions)
-			if err != nil {
-				return stacktrace.Propagate(err, "Failed to update Namespace: %s", name)
-			}
+		}
+		_, err = manager.kubernetesClient.clientSet.CoreV1().Namespaces().Update(ctx, existingNamespace, globalUpdateOptions)
+		if err != nil {
+			return stacktrace.Propagate(err, "Failed to update Namespace: %s", name)
 		}
 	} else {
 		newNamespace := corev1.Namespace{


### PR DESCRIPTION
The istio system namespace labels were altered even they should not be.  This is because some resources like the envoy filters are under that namespace.  This resulted in two Kardinal labelled namespaces.  This change also fixes the baseline namespace labels update.