### PR TITLE
fix: Clarify the manager CLI command deploy kontrol service location argument

### DIFF
--- a/.github/workflows/ci-e2e-tests.yml
+++ b/.github/workflows/ci-e2e-tests.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Deploy Kardinal manager
         run: |
-          KARDINAL_CLI_DEV_MODE=TRUE /tmp/kardinal-cli manager deploy local-minikube
+          KARDINAL_CLI_DEV_MODE=TRUE /tmp/kardinal-cli manager deploy local-kardinal-kontrol
 
       - name: Deploy boutique demo manifest
         run: |

--- a/kardinal-cli/cmd/root.go
+++ b/kardinal-cli/cmd/root.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"kardinal.cli/kubernetes"
 	"log"
 	"net"
 	"net/http"
@@ -16,6 +15,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"kardinal.cli/kubernetes"
 
 	"gopkg.in/yaml.v3"
 	"kardinal.cli/consts"
@@ -471,9 +472,10 @@ var topologyManifestCmd = &cobra.Command{
 }
 
 var deployManagerCmd = &cobra.Command{
-	Use:       fmt.Sprintf("deploy [kontrol location] accepted values: %s and %s ", kontrol.KontrolLocationLocalMinikube, kontrol.KontrolLocationKloudKontrol),
+	Use:       fmt.Sprintf("deploy [kardinal-kontrol service location] accepted values: %s and %s ", kontrol.KontrolLocationLocal, kontrol.KontrolLocationKloud),
 	Short:     "Deploy Kardinal manager into the cluster",
-	ValidArgs: []string{kontrol.KontrolLocationLocalMinikube, kontrol.KontrolLocationKloudKontrol},
+	Long:      "The Kardinal Manager retrieves the latest configuration from the Kardinal Kontrol service and applies changes to the user K8S topology.  The Kardinal Kontrol service can be the one running in the Kardinal Cloud or can be the one deployed locally.",
+	ValidArgs: []string{kontrol.KontrolLocationLocal, kontrol.KontrolLocationKloud},
 	Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		kontrolLocation := args[0]
@@ -1087,10 +1089,10 @@ func getKontrolBaseURLForManager() (string, error) {
 	)
 
 	switch kontrolLocation {
-	case kontrol.KontrolLocationLocalMinikube:
+	case kontrol.KontrolLocationLocal:
 		scheme = httpSchme
 		host = localMinikubeKontrolAPIHost
-	case kontrol.KontrolLocationKloudKontrol:
+	case kontrol.KontrolLocationKloud:
 		scheme = httpsScheme
 		host = kloudKontrolAPIHost
 	default:

--- a/kardinal-cli/deployment/deployment.go
+++ b/kardinal-cli/deployment/deployment.go
@@ -3,8 +3,9 @@ package deployment
 import (
 	"bytes"
 	"context"
-	"kardinal.cli/kubernetes"
 	"text/template"
+
+	"kardinal.cli/kubernetes"
 
 	"kardinal.cli/kontrol"
 
@@ -207,9 +208,9 @@ func DeployKardinalManagerInCluster(ctx context.Context, clusterResourcesURL str
 	var imagePullPolicy string
 
 	switch kontrolLocation {
-	case kontrol.KontrolLocationLocalMinikube:
+	case kontrol.KontrolLocationLocal:
 		imagePullPolicy = "IfNotPresent"
-	case kontrol.KontrolLocationKloudKontrol:
+	case kontrol.KontrolLocationKloud:
 		imagePullPolicy = "Always"
 	default:
 		stacktrace.NewError("invalid Kontrol location: %s", kontrolLocation)

--- a/kardinal-cli/kontrol/location.go
+++ b/kardinal-cli/kontrol/location.go
@@ -1,15 +1,19 @@
 package kontrol
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/kurtosis-tech/stacktrace"
 	"github.com/sirupsen/logrus"
 	"kardinal.cli/host_machine_directories"
-	"os"
 )
 
 const (
-	KontrolLocationLocalMinikube               = "local-minikube"
-	KontrolLocationKloudKontrol                = "kloud-kontrol"
+	KontrolLocationLocal                       = "local-kardinal-kontrol"
+	KontrolLocationKloud                       = "kloud-kardinal-kontrol"
+	OldKontrolLocationLocal                    = "local-minikube"
+	OldKontrolLocationKloud                    = "kloud-kontrol"
 	kontrolLocationFilePermissions os.FileMode = 0644
 )
 
@@ -33,9 +37,10 @@ func GetKontrolLocation() (string, error) {
 		return "", stacktrace.Propagate(err, "An error occurred getting the Kontrol location filepath")
 	}
 
+	fmt.Println(kontrolLocationFilepath)
 	_, err = os.Stat(kontrolLocationFilepath)
 	if err != nil {
-		return "", stacktrace.Propagate(err, "An error occurred getting the Kontrol location  file info")
+		return "", stacktrace.Propagate(err, "An error occurred getting the Kontrol location file info")
 	}
 
 	kontrolLocationFileBytes, err := os.ReadFile(kontrolLocationFilepath)
@@ -44,6 +49,12 @@ func GetKontrolLocation() (string, error) {
 	}
 
 	kontrolLocationFileStr := string(kontrolLocationFileBytes)
+	switch kontrolLocationFileStr {
+	case OldKontrolLocationLocal:
+		kontrolLocationFileStr = KontrolLocationLocal
+	case OldKontrolLocationKloud:
+		kontrolLocationFileStr = KontrolLocationKloud
+	}
 
 	logrus.Infof("Using Kontrol location %s", kontrolLocationFileStr)
 	return kontrolLocationFileStr, nil


### PR DESCRIPTION
Some users are confused about the kardinal kontrol service location argument.  Some of them are not able to differentiate between the kardinal manager location and the kontrol service location.  I myself was also confused when I saw the manager deploy command.