### PR TITLE
docs: plugin index

### DIFF
--- a/website/app/docs/concepts/plugins/page.mdx
+++ b/website/app/docs/concepts/plugins/page.mdx
@@ -2,10 +2,26 @@ export const metadata = {
   title: "Kardinal Docs | Plugins",
 };
 
-# Plugins for State Isolation
+# Plugins
 
 Kardinal leverages a plugin system that allows developers to encode logic of how dev versions of stateful services (databases, queues, APIs) and external services (Stripe API, Mailchimp, managed database like Amazon RDS or Neon DB) should be handled.
 Plugins work by offering developers an api to write Python-based scripts that can dynamically alter Kubernetes deployment specs, providing a way to handle stateful and external services in a safer manner.
+
+Kardinal supports a number of plugins already, with more currently in development or planned for future development. If there is a particular plugin you are interested in that is not on this list, please open a [github issue](https://github.com/kurtosis-tech/kardinal/issues) with more details.
+
+| Plugin | Description | Status |
+| ------------- | ------------- | ------------- |
+| [Redis Sidecar Plugin](https://github.com/kurtosis-tech/redis-sidecar-plugin) | Adds a thin layer over redis that allows for shared reads and isolated writes| ✅ Live |
+| [Neon DB Plugin](https://github.com/kurtosis-tech/neondb-plugin) | Creates a new branch for the database you are using | ✅ Live |
+| [Postgres Seed Plugin](https://github.com/kurtosis-tech/postgres-seed-plugin) | Allows you to spin up a postgres database with seeded data | ✅ Live |
+| [AWS RDS Plugin](https://github.com/kurtosis-tech/aws-rds-plugin) | Manage the AWS RDS service creation and deletion for dev flows | ✅ Live |
+| [Dummy Plugin](https://github.com/kurtosis-tech/dummy-plugin) | Example Kardinal plugin, useful as a template | ✅ Live |
+| [AWS SQS Plugin](concepts/plugins#plugins) | Manage dev flow interactions with AWS SQS | 🚧 In development |
+| [AWS S3 Plugin](concepts/plugins#plugins) | Manage dev flow interactions with AWS S3 | 🕑 Planned |
+| [MySQL Plugin](concepts/plugins#plugins) | Manage dev flow interactions with MySQL | 🕑 Planned |
+| [Cloud SQL Plugin](concepts/plugins#plugins) | Manage dev flow interactions with Google Cloud SQL | 🕑 Planned |
+| [Azure SQL Plugin](concepts/plugins#plugins) | Manage dev flow interactions with Azure SQL | 🕑 Planned |
+| [Stripe Plugin](concepts/plugins#plugins) | Manage dev flow interactions with Stripe | 🕑 Planned |
 
 ## How It Works
 
@@ -370,10 +386,3 @@ spec:
 Anytime a dev version of `cartservice` is called, the `neondb-plugin` is called. The plugin will create a dev database branch, forked off of main. It will then return a modified deployment spec starting a dev version of the cartservice that points to the dev database branch.
 Notice how here, the plugin annotation goes on the service depending on the external service and this is the deployment spec being modified, in this case, the `cartservice`.
 Also, notice we add `type:external` and `serviceName:neon-postgres-db` to tell Kardinal this service is external and how to refer to it.
-
-## Existing plugins
-
-1. [Redis Sidecar Plugin](https://github.com/kurtosis-tech/redis-sidecar-plugin) - Adds a thin layer over redis that allows for shared reads and isolated writes
-1. [Neon DB Plugin](https://github.com/kurtosis-tech/neondb-plugin) - Creates a new branch for the database you are using
-1. [Postgres Seed Plugin](https://github.com/kurtosis-tech/postgres-seed-plugin) - Allows you to spin up a postgres database with seeded data
-1. [AWS RDS Plugin](https://github.com/kurtosis-tech/aws-rds-plugin) - Manage the AWS RDS service creation and deletion for dev flows

--- a/website/components/DocsLayout.tsx
+++ b/website/components/DocsLayout.tsx
@@ -55,26 +55,36 @@ namespace S {
     h5,
     h6 {
       margin-bottom: 0;
-      margin-top: 0;
+      margin-top: 1em;
       color: var(--foreground-dark);
-      font-size: 42px;
+      font-size: 48px;
       font-style: normal;
       font-weight: 500;
       line-height: normal;
       letter-spacing: unset;
 
       @media (max-width: 768px) {
-        font-size: 24px;
+        font-size: 32px;
       }
     }
 
-    h3 {
+    h2 {
       font-size: 32px;
       font-weight: 600;
       line-height: 1.33;
 
       @media (max-width: 768px) {
         font-size: 18px;
+      }
+    }
+
+    h3 {
+      font-size: 24px;
+      font-weight: 500;
+      line-height: 1.33;
+
+      @media (max-width: 768px) {
+        font-size: 16px;
       }
     }
 
@@ -156,6 +166,7 @@ namespace S {
       margin-left: -1px;
       padding: 12px 8px;
       max-width: 256px;
+      text-align: left;
     }
 
     th {

--- a/website/components/DocsNav.tsx
+++ b/website/components/DocsNav.tsx
@@ -35,7 +35,7 @@ const navItems: NavItem[] = [
     title: "Concepts",
     children: [
       { path: "flows", title: "Flows" },
-      { path: "plugins", title: "Plugins for State Isolation" },
+      { path: "plugins", title: "Plugins" },
       { path: "templates", title: "Flow Templates" },
     ],
   },


### PR DESCRIPTION
Implements plugin index as a table on the existing plugins page. Also re-works some heading font sizes on the docs to improve readability.

<img width="926" alt="image" src="https://github.com/user-attachments/assets/f7999b11-4a85-4b80-bb9d-f1d218e5cbbf">
