### PR TITLE
fix: fix race condition with docs voting feature

### DIFF
--- a/website/context/VotingContext.tsx
+++ b/website/context/VotingContext.tsx
@@ -37,7 +37,16 @@ interface VotingContextProps {
   getVoteCount: (feature: string) => number;
 }
 
-const VotingContext = createContext<VotingContextProps | undefined>(undefined);
+const VotingContext = createContext<VotingContextProps>({
+  localStorageVotes: [],
+  features: [],
+  upvote: async () => {},
+  downvote: async () => {},
+  getVoteStatus: () => "none",
+  isUpvoted: () => false,
+  isDownvoted: () => false,
+  getVoteCount: () => 0,
+});
 
 const doApiRequest = async (
   method: "GET" | "POST",


### PR DESCRIPTION
This fixes a race condition that could occasionally cause the page to show an error if the rendering of the page completed before the request to the voting backend API completed. This fixes this race condition by providing stubbed / initial values in the voting context instead of `undefined`. 

The error that was occasionally reproducible": 
<img width="948" alt="image" src="https://github.com/user-attachments/assets/1ba87db6-2aad-4879-b153-2d8dd6f3743a">
