### PR TITLE
fix: avoid trying to delete default namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,3 +303,4 @@ kardinal flow telepresence-intercept {{flow-id}} {{service-name}} {{local-port}}
 - Ask questions and get help in our community [forum](https://discuss.kardinal.dev).
 - Read our [blog](https://blog.kardinal.dev/) for tips from developers and creators.
 
+

--- a/kardinal-manager/kardinal-manager/cluster_manager/cluster_manager.go
+++ b/kardinal-manager/kardinal-manager/cluster_manager/cluster_manager.go
@@ -34,6 +34,8 @@ const (
 	// TODO move these values to a shared library between Kardinal Manager, Kontrol and Kardinal CLI
 	kardinalLabelKey = "kardinal.dev"
 	enabledKardinal  = "enabled"
+
+	defaultNamespace = "default"
 )
 
 var (
@@ -428,6 +430,11 @@ func (manager *ClusterManager) removeKardinalNamespaces(ctx context.Context) err
 	}
 
 	for _, namespace := range kardinalNamespaces.Items {
+
+		if namespace.GetName() == defaultNamespace {
+			continue
+		}
+
 		if err := manager.removeNamespace(ctx, &namespace); err != nil {
 			return stacktrace.Propagate(err, "an error occurred while removing Kardinal namespace '%s'", namespace.GetName())
 		}

--- a/kardinal-manager/kardinal-manager/cluster_manager/cluster_manager_test.go
+++ b/kardinal-manager/kardinal-manager/cluster_manager/cluster_manager_test.go
@@ -7,10 +7,6 @@ import (
 	"testing"
 )
 
-const (
-	defaultNamespace = "default"
-)
-
 func TestClusterManager_GetVirtualServices(t *testing.T) {
 	ctx := context.Background()
 	clusterManager, err := getClusterManagerForTesting(t)


### PR DESCRIPTION
Deleting the `default` namespace is impossible because Kubernetes API will block it. Still, it's generated an error in the Kardinal manager, so we avoid sending the request to the API.