### PR TITLE
feat: [pt1.] version cmd

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722589758,
-        "narHash": "sha256-sbbA8b6Q2vB/t/r1znHawoXLysCyD4L/6n6/RykiSnA=",
+        "lastModified": 1728509152,
+        "narHash": "sha256-tQo1rg3TlwgyI8eHnLvZSlQx9d/o2Rb4oF16TfaTOw0=",
         "owner": "nix-community",
         "repo": "gomod2nix",
-        "rev": "4e08ca09253ef996bd4c03afa383b23e35fe28a1",
+        "rev": "d5547e530464c562324f171006fc8f639aa01c9f",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726320982,
-        "narHash": "sha256-RuVXUwcYwaUeks6h3OLrEmg14z9aFXdWppTWPMTwdQw=",
+        "lastModified": 1728909085,
+        "narHash": "sha256-WLxED18lodtQiayIPDE5zwAfkPJSjHJ35UhZ8h3cJUg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f7492cce28977fbf8bd12c72af08b1f6c7c3e49",
+        "rev": "c0b1da36f7c34a7146501f684e9ebdf15d2bebf8",
         "type": "github"
       },
       "original": {

--- a/kardinal-cli/cmd/root.go
+++ b/kardinal-cli/cmd/root.go
@@ -32,6 +32,7 @@ import (
 	"kardinal.cli/kontrol"
 	"kardinal.cli/tenant"
 
+	"github.com/kurtosis-tech/kardinal/kardinal_version"
 	api "github.com/kurtosis-tech/kardinal/libs/cli-kontrol-api/api/golang/client"
 	api_types "github.com/kurtosis-tech/kardinal/libs/cli-kontrol-api/api/golang/types"
 	appv1 "k8s.io/api/apps/v1"
@@ -622,6 +623,15 @@ var tenantShowCmd = &cobra.Command{
 	},
 }
 
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show version of Kardinal CLI running",
+	Args:  cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("%s\n", kardinal_version.KardinalVersion)
+	},
+}
+
 func init() {
 	devMode = false
 	if os.Getenv("KARDINAL_CLI_DEV_MODE") == "TRUE" {
@@ -637,6 +647,7 @@ func init() {
 	rootCmd.AddCommand(reportInstall)
 	rootCmd.AddCommand(topologyCmd)
 	rootCmd.AddCommand(tenantCmd)
+	rootCmd.AddCommand(versionCmd)
 
 	flowCmd.AddCommand(listCmd, createCmd, deleteCmd, telepresenceInterceptCmd)
 	managerCmd.AddCommand(deployManagerCmd, removeManagerCmd)

--- a/kardinal-cli/go.mod
+++ b/kardinal-cli/go.mod
@@ -1,6 +1,8 @@
 module kardinal.cli
 
-go 1.22.3
+go 1.22.5
+
+toolchain go1.22.6
 
 replace (
 	github.com/kurtosis-tech/kardinal/kardinal_version => ../kardinal_version

--- a/kardinal-cli/go.mod
+++ b/kardinal-cli/go.mod
@@ -1,14 +1,16 @@
 module kardinal.cli
 
-go 1.22.0
+go 1.22.3
 
-toolchain go1.22.3
-
-replace github.com/kurtosis-tech/kardinal/libs/cli-kontrol-api => ../libs/cli-kontrol-api
+replace (
+	github.com/kurtosis-tech/kardinal/kardinal_version => ../kardinal_version
+	github.com/kurtosis-tech/kardinal/libs/cli-kontrol-api => ../libs/cli-kontrol-api
+)
 
 require (
 	github.com/adrg/xdg v0.4.0
 	github.com/google/uuid v1.6.0
+	github.com/kurtosis-tech/kardinal/kardinal_version v0.0.0-00010101000000-000000000000
 	github.com/kurtosis-tech/stacktrace v0.0.0-20211028211901-1c67a77b5409
 	github.com/samber/lo v1.46.0
 	github.com/segmentio/analytics-go/v3 v3.3.0

--- a/kardinal_version/go.mod
+++ b/kardinal_version/go.mod
@@ -1,0 +1,3 @@
+module github.com/kurtosis-tech/kardinal/kardinal_version
+
+go 1.22.5

--- a/kardinal_version/gomod2nix.toml
+++ b/kardinal_version/gomod2nix.toml
@@ -1,0 +1,594 @@
+schema = 3
+
+[mod]
+  [mod."cloud.google.com/go"]
+    version = "v0.110.2"
+    hash = "sha256-0IJ/EPUsG7JiFkJKw83hl+HLog1DIXPPvLPmvrXjDP0="
+  [mod."cloud.google.com/go/compute"]
+    version = "v1.20.1"
+    hash = "sha256-HQvSLdoSagQsuqOb/D9+xMc8nE9Y44Z30rQgd2AGEr8="
+  [mod."cloud.google.com/go/compute/metadata"]
+    version = "v0.2.3"
+    hash = "sha256-kYB1FTQRdTDqCqJzSU/jJYbVUGyxbkASUKbEs36FUyU="
+  [mod."github.com/BurntSushi/toml"]
+    version = "v1.3.2"
+    hash = "sha256-FIwyH67KryRWI9Bk4R8s1zFP0IgKR4L66wNQJYQZLeg="
+  [mod."github.com/CloudyKit/fastprinter"]
+    version = "v0.0.0-20200109182630-33d98a066a53"
+    hash = "sha256-KUuNS6OlaDUfpKIvZWJr8fiUR8ki/hUwMZiunNj0cxo="
+  [mod."github.com/CloudyKit/jet/v6"]
+    version = "v6.2.0"
+    hash = "sha256-22PSPgN9ajVbm0gbhnrPWgroacipQaL7AMLsECzzd7A="
+  [mod."github.com/Joker/jade"]
+    version = "v1.1.3"
+    hash = "sha256-264xyHGlF/hqJGY28YAFFh4VcsoJ0W/5HrgcJAdLKZs="
+  [mod."github.com/NYTimes/gziphandler"]
+    version = "v0.0.0-20170623195520-56545f4a5d46"
+    hash = "sha256-4mTVrxEH1Cu3MVhm/nB+Zm8b2oYS4SecOHjnbT5Pk7s="
+  [mod."github.com/RaveNoX/go-jsoncommentstrip"]
+    version = "v1.0.0"
+    hash = "sha256-bD0Jb4TGkJhuJ1MGptK+eTpGseRom1QRO9hwxnoF60U="
+  [mod."github.com/Shopify/goreferrer"]
+    version = "v0.0.0-20220729165902-8cddb4f5de06"
+    hash = "sha256-zyP8NdtP79I7DOH7bUw54pY5ge1yWkSIbh4jnp8gel4="
+  [mod."github.com/adrg/xdg"]
+    version = "v0.4.0"
+    hash = "sha256-zGjkdUQmrVqD6rMO9oDY+TeJCpuqnHyvkPCaXDlac/U="
+  [mod."github.com/ahmetb/gen-crd-api-reference-docs"]
+    version = "v0.3.0"
+    hash = "sha256-9W0jxXQn3E5bJ24SURs2tO1odSep/mIp0OIpjKCDM18="
+  [mod."github.com/andybalholm/brotli"]
+    version = "v1.0.5"
+    hash = "sha256-/qS8wU8yZQJ+uTOg66rEl9s7spxq9VIXF5L1BcaEClc="
+  [mod."github.com/apapsch/go-jsonmerge/v2"]
+    version = "v2.0.0"
+    hash = "sha256-xp/1B6XUN2EbddBfoUkTV3oTk+34m4kOZP+66HhfLg4="
+  [mod."github.com/armon/go-socks5"]
+    version = "v0.0.0-20160902184237-e75332964ef5"
+    hash = "sha256-2F/mqTbr7jhtlZ0UGMRfHrjXbHbGwTJi951y4CQInIA="
+  [mod."github.com/asaskevich/govalidator"]
+    version = "v0.0.0-20190424111038-f61b66f89f4a"
+    hash = "sha256-pcrINvdGpQExaSQv1j19L0NLWcvZL8jXQMsvMlVq8ss="
+  [mod."github.com/aymerick/douceur"]
+    version = "v0.2.0"
+    hash = "sha256-NiBX8EfOvLXNiK3pJaZX4N73YgfzdrzRXdiBFe3X3sE="
+  [mod."github.com/bmatcuk/doublestar"]
+    version = "v1.1.1"
+    hash = "sha256-mcR+gZ11pja98RwW7eN6T6TwC07ujPmQ8CcyH45r//0="
+  [mod."github.com/bmizerany/assert"]
+    version = "v0.0.0-20160611221934-b7ed37b82869"
+    hash = "sha256-WnAmAW0f97kZoGhBmIGNBjblTh02O9WfPrH9RD0PHqI="
+  [mod."github.com/bsm/ginkgo/v2"]
+    version = "v2.12.0"
+    hash = "sha256-rZ9AF2RPWwQcgFmh3bmUXDaTLL14fQfPtv+DuC8xqzQ="
+  [mod."github.com/bsm/gomega"]
+    version = "v1.27.10"
+    hash = "sha256-EltjBddI8lJOxiONk2GgbjtHp7ysV00CK7BRVbAOLZ4="
+  [mod."github.com/bytedance/sonic"]
+    version = "v1.10.0-rc3"
+    hash = "sha256-K8194CwIvSvMpaqMtLWV9YSfA0Q5hpHV8oHAnwwn0T8="
+  [mod."github.com/cespare/xxhash/v2"]
+    version = "v2.3.0"
+    hash = "sha256-7hRlwSR+fos1kx4VZmJ/7snR7zHh8ZFKX+qqqqGcQpY="
+  [mod."github.com/chenzhuoyu/base64x"]
+    version = "v0.0.0-20230717121745-296ad89f973d"
+    hash = "sha256-o1qbpdkfbXE/DWW1ZFgTLPS2HGS0Ib69dbd6zO8CCWk="
+  [mod."github.com/chenzhuoyu/iasm"]
+    version = "v0.9.0"
+    hash = "sha256-xlZIAcRAD9dufk7JZfyKyiBzw6Gzfj4oKh2wbjKukQg="
+  [mod."github.com/chzyer/logex"]
+    version = "v1.1.10"
+    hash = "sha256-BNOaV/CFAqOymWW3R2m1sCikdCwFZM/pVkylzoeU6yI="
+  [mod."github.com/chzyer/readline"]
+    version = "v0.0.0-20180603132655-2972be24d48e"
+    hash = "sha256-2Uj5LGpHEbLQG3d/7z9AL8DknUBZyoTAMs4j+VVDmIA="
+  [mod."github.com/chzyer/test"]
+    version = "v0.0.0-20180213035817-a1ea475d72b1"
+    hash = "sha256-U0irpUSqegh7Nzg1ErPuyjESOcIXXOWf7ikKMbES2mY="
+  [mod."github.com/cpuguy83/go-md2man/v2"]
+    version = "v2.0.3"
+    hash = "sha256-FAMxR5eBO9LQp6ev1b7zaPUS5aoNz1GtsPpoArjiJVw="
+  [mod."github.com/creack/pty"]
+    version = "v1.1.9"
+    hash = "sha256-Rj6c4/3IApJcS36iPVIEdlMSC/SWmywnpqk1500ik5k="
+  [mod."github.com/davecgh/go-spew"]
+    version = "v1.1.1"
+    hash = "sha256-nhzSUrE1fCkN0+RL04N4h8jWmRFPPPWbCuDc7Ss0akI="
+  [mod."github.com/deepmap/oapi-codegen/v2"]
+    version = "v2.2.1-0.20240604070534-2f0ff757704b"
+    hash = "sha256-xexjMUdpXoOS9i8dA3MD4mBFHcXSnk9y6iKZfeSXjHg="
+  [mod."github.com/dgryski/go-rendezvous"]
+    version = "v0.0.0-20200823014737-9f7001d12a5f"
+    hash = "sha256-n/7xo5CQqo4yLaWMSzSN1Muk/oqK6O5dgDOFWapeDUI="
+  [mod."github.com/emicklei/go-restful/v3"]
+    version = "v3.12.0"
+    hash = "sha256-w9mYeZiOWYEd5NLkOHYbaElfcbNurV6trMtbv2KPvL0="
+  [mod."github.com/evanphx/json-patch"]
+    version = "v5.7.0+incompatible"
+    hash = "sha256-6aTV41slcMtqRp2PdL4CKTDPUMoIXNP/tOgduzgGMCU="
+  [mod."github.com/evanphx/json-patch/v5"]
+    version = "v5.9.0"
+    hash = "sha256-KG3giQTztHy6SX0wF2/Htje4MPs+1oEzfWhKDE0xl4U="
+  [mod."github.com/fatih/color"]
+    version = "v1.16.0"
+    hash = "sha256-Aq/SM28aPJVzvapllQ64R/DM4aZ5CHPewcm/AUJPyJQ="
+  [mod."github.com/fatih/structs"]
+    version = "v1.1.0"
+    hash = "sha256-OCmubTLF1anwNnkvFZDYHnF6hFlX0WDoe/9+dDlaMPM="
+  [mod."github.com/felixge/fgprof"]
+    version = "v0.9.3"
+    hash = "sha256-Q0EOEvkwqNbB/yR85MGrbzoahGbWbSw8ISmP0KTdAw8="
+  [mod."github.com/flosch/pongo2/v4"]
+    version = "v4.0.2"
+    hash = "sha256-MQa2y64XpNPa3dKEerYJT5eFTrAk7flts9h2LG1QQQY="
+  [mod."github.com/fxamacker/cbor/v2"]
+    version = "v2.6.0"
+    hash = "sha256-8EMjmc2FYVb0OXuzU1FWkSqYEtJjYdIT2PWsChoiTyQ="
+  [mod."github.com/gabriel-vasile/mimetype"]
+    version = "v1.4.2"
+    hash = "sha256-laV+IkgbnEG07h1eFfPISqp0ctnLXfzchz/CLR1lftk="
+  [mod."github.com/getkin/kin-openapi"]
+    version = "v0.125.0"
+    hash = "sha256-4g7MoGIyH80ek9SEqHYV1TjsYAx+wTzvipEKhfddGYA="
+  [mod."github.com/gin-contrib/sse"]
+    version = "v0.1.0"
+    hash = "sha256-zYbMTao+1F+385Lvsba9roLmmt9eYqr57sUWo0LCVhw="
+  [mod."github.com/gin-gonic/gin"]
+    version = "v1.9.1"
+    hash = "sha256-3FHywH5QuhTeQcdF8v06jt9vIkH0ON6ydpMYciAc8xQ="
+  [mod."github.com/go-logr/logr"]
+    version = "v1.4.1"
+    hash = "sha256-WM4badoqxXlBmqCRrnmtNce63dLlr/FJav3BJSYHvaY="
+  [mod."github.com/go-openapi/jsonpointer"]
+    version = "v0.21.0"
+    hash = "sha256-bB8XTzo4hzXemi8Ey3tIXia3mfn38bvwIzKYLJYC650="
+  [mod."github.com/go-openapi/jsonreference"]
+    version = "v0.21.0"
+    hash = "sha256-lkFb/kP0qt8L1jsLYLt+jXTY6jSk5SYJbfgAKKVlQYQ="
+  [mod."github.com/go-openapi/swag"]
+    version = "v0.23.0"
+    hash = "sha256-D5CzsSQ3SYJLwXT6BDahnG66LI8du59Dy1mY4KutA7A="
+  [mod."github.com/go-playground/locales"]
+    version = "v0.14.1"
+    hash = "sha256-BMJGAexq96waZn60DJXZfByRHb8zA/JP/i6f/YrW9oQ="
+  [mod."github.com/go-playground/universal-translator"]
+    version = "v0.18.1"
+    hash = "sha256-2/B2qP51zfiY+k8G0w0D03KXUc7XpWj6wKY7NjNP/9E="
+  [mod."github.com/go-playground/validator/v10"]
+    version = "v10.14.1"
+    hash = "sha256-13J8JqIuhI7lbBagaR7INykFRXqRbB7tjXtMZI3PNvA="
+  [mod."github.com/go-task/slim-sprig"]
+    version = "v0.0.0-20230315185526-52ccab3ef572"
+    hash = "sha256-D6NjCQbcYC53NdwzyAm4i9M1OjTJIVu4EIt3AD/Vxfg="
+  [mod."github.com/go-test/deep"]
+    version = "v1.0.8"
+    hash = "sha256-AKOpW32qcq1BTVEPC6MshiFA3ROucnmlJMIfvwYXvNY="
+  [mod."github.com/gobuffalo/flect"]
+    version = "v1.0.2"
+    hash = "sha256-r0UXCY4OI/VIawB38WmZ4nAe/4qKsyqT5LD+UVhOylw="
+  [mod."github.com/goccy/go-json"]
+    version = "v0.10.2"
+    hash = "sha256-6fMD2/Rku8HT0zDdeA23pX0YxbohiIOC8OJNYbylJTQ="
+  [mod."github.com/gogo/protobuf"]
+    version = "v1.3.2"
+    hash = "sha256-pogILFrrk+cAtb0ulqn9+gRZJ7sGnnLLdtqITvxvG6c="
+  [mod."github.com/golang-jwt/jwt"]
+    version = "v3.2.2+incompatible"
+    hash = "sha256-LOkpuXhWrFayvVf1GOaOmZI5YKEsgqVSb22aF8LnCEM="
+  [mod."github.com/golang/groupcache"]
+    version = "v0.0.0-20210331224755-41bb18bfe9da"
+    hash = "sha256-7Gs7CS9gEYZkbu5P4hqPGBpeGZWC64VDwraSKFF+VR0="
+  [mod."github.com/golang/protobuf"]
+    version = "v1.5.4"
+    hash = "sha256-N3+Lv9lEZjrdOWdQhFj6Y3Iap4rVLEQeI8/eFFyAMZ0="
+  [mod."github.com/golang/snappy"]
+    version = "v0.0.4"
+    hash = "sha256-Umx+5xHAQCN/Gi4HbtMhnDCSPFAXSsjVbXd8n5LhjAA="
+  [mod."github.com/gomarkdown/markdown"]
+    version = "v0.0.0-20230922112808-5421fefb8386"
+    hash = "sha256-N3qjdMq0L4toiTu2rut9sSPR/cA7bEe/bZ1iEVNzXOE="
+  [mod."github.com/google/btree"]
+    version = "v1.0.1"
+    hash = "sha256-1PIeFGgUL4BK/StL/D12pg9bEQ5HfMT/fMLdus4pZTs="
+  [mod."github.com/google/gnostic-models"]
+    version = "v0.6.8"
+    hash = "sha256-YzA/XpvPyfdplJtHmAUdQk9P+j0NBwHhW9nj1DaGaoQ="
+  [mod."github.com/google/go-cmp"]
+    version = "v0.6.0"
+    hash = "sha256-qgra5jze4iPGP0JSTVeY5qV5AvEnEu39LYAuUCIkMtg="
+  [mod."github.com/google/gofuzz"]
+    version = "v1.2.0"
+    hash = "sha256-T6Gz741l45L3F6Dt7fiAuQvQQg59Qtap3zG05M2cfqU="
+  [mod."github.com/google/pprof"]
+    version = "v0.0.0-20211214055906-6f57359322fd"
+    hash = "sha256-Ju5Ke03QOM0YbubQT8jPPcjJq2mgpua8RmqB1UUSLAw="
+  [mod."github.com/google/s2a-go"]
+    version = "v0.1.4"
+    hash = "sha256-amTAj6SNERMPxAA43KrzwYgu6GMooayfHCsdkoTI17c="
+  [mod."github.com/google/uuid"]
+    version = "v1.6.0"
+    hash = "sha256-VWl9sqUzdOuhW0KzQlv0gwwUQClYkmZwSydHG2sALYw="
+  [mod."github.com/googleapis/enterprise-certificate-proxy"]
+    version = "v0.2.3"
+    hash = "sha256-4yaBdpdRuv5vkGlwxKPlZ/IVSeHlcP9PJaLcyn4wNJk="
+  [mod."github.com/googleapis/gax-go/v2"]
+    version = "v2.11.0"
+    hash = "sha256-jWfuxmawmfPNTt7iWn9StsC5yofMupkr1IUZbjTxrgQ="
+  [mod."github.com/gorilla/css"]
+    version = "v1.0.0"
+    hash = "sha256-Mmt/IqHpgrtWpbr/AKcJyf/USQTqEuv1HVivY4eHzoQ="
+  [mod."github.com/gorilla/mux"]
+    version = "v1.8.1"
+    hash = "sha256-nDABvAhlYgxUW2N/brrep7NkQXoSGcHhA+XI4+tK0F0="
+  [mod."github.com/gorilla/websocket"]
+    version = "v1.5.1"
+    hash = "sha256-eHZ/U+eeE5tSgWc1jEDuBwtTRbXKP9fqP9zfW4Zw8T0="
+  [mod."github.com/gregjones/httpcache"]
+    version = "v0.0.0-20180305231024-9cad4c3443a7"
+    hash = "sha256-2ngFfFuSm8YSTNZWGQuN5yTpsXlwY2R8aaIzjDnjTXI="
+  [mod."github.com/ianlancetaylor/demangle"]
+    version = "v0.0.0-20210905161508-09a460cdf81d"
+    hash = "sha256-Kc79EqT4tPl8tf/iWg96TiJlYXalJBPS78XLTbatGhc="
+  [mod."github.com/imdario/mergo"]
+    version = "v0.3.16"
+    hash = "sha256-gh2TEAq8YrZOEAf6SFW4AIcEEUguD68G+7/VUnBeWwM="
+  [mod."github.com/inconshreveable/mousetrap"]
+    version = "v1.1.0"
+    hash = "sha256-XWlYH0c8IcxAwQTnIi6WYqq44nOKUylSWxWO/vi+8pE="
+  [mod."github.com/invopop/yaml"]
+    version = "v0.2.0"
+    hash = "sha256-RxeDuvwOSWYaLc8Q7T39rfFT3bZX3g9Bu0RFwxH6sLw="
+  [mod."github.com/iris-contrib/schema"]
+    version = "v0.0.6"
+    hash = "sha256-2jk46kocpQGmswalwwFI5P8B4AHR1xkTnbPdtFa9VFo="
+  [mod."github.com/josharian/intern"]
+    version = "v1.0.0"
+    hash = "sha256-LJR0QE2vOQ2/2shBbO5Yl8cVPq+NFrE3ers0vu9FRP0="
+  [mod."github.com/json-iterator/go"]
+    version = "v1.1.12"
+    hash = "sha256-To8A0h+lbfZ/6zM+2PpRpY3+L6725OPC66lffq6fUoM="
+  [mod."github.com/juju/gnuflag"]
+    version = "v0.0.0-20171113085948-2ce1bb71843d"
+    hash = "sha256-D66Gq0FC0k+86qOMZrpEsQ+6HzqkBibCdHXZsN1BfmY="
+  [mod."github.com/kataras/blocks"]
+    version = "v0.0.7"
+    hash = "sha256-sXTcBIPuifzEgqe8m0Oe45A19egRGY1C+ZndaKWxxuY="
+  [mod."github.com/kataras/golog"]
+    version = "v0.1.9"
+    hash = "sha256-o/l8xq0bNRtjBbnCTjiIg4K2SXP3w1a+df9nBVI3VWQ="
+  [mod."github.com/kataras/iris/v12"]
+    version = "v12.2.6-0.20230908161203-24ba4e8933b9"
+    hash = "sha256-49LV2uv5+jKCANxIMTdDp7i++kWlp91oiFhnPvnVkQM="
+  [mod."github.com/kataras/pio"]
+    version = "v0.0.12"
+    hash = "sha256-+DnDBEQde7iLVBE9XQmEhYpR6YTDeVplniQWrZH964w="
+  [mod."github.com/kataras/sitemap"]
+    version = "v0.0.6"
+    hash = "sha256-NmAX6wCT1Z5n44O5TId4iovDUxH/ukgLKEGmchAMS8Q="
+  [mod."github.com/kataras/tunnel"]
+    version = "v0.0.4"
+    hash = "sha256-yhCeH7eM8F+BxOy/y5MyAI0F0ghfLFUB/5aemIBZM54="
+  [mod."github.com/kisielk/errcheck"]
+    version = "v1.5.0"
+    hash = "sha256-ZmocFXtg+Thdup+RqDYC/Td3+m1nS0FydZecfsWXIzI="
+  [mod."github.com/kisielk/gotool"]
+    version = "v1.0.0"
+    hash = "sha256-lsdQkue8gFz754PGqczUnvGiCQq87SruQtdrDdQVTpE="
+  [mod."github.com/klauspost/compress"]
+    version = "v1.16.7"
+    hash = "sha256-8miX/lnXyNLPSqhhn5BesLauaIAxETpQpWtr1cu2f+0="
+  [mod."github.com/klauspost/cpuid/v2"]
+    version = "v2.2.5"
+    hash = "sha256-/M8CHNah2/EPr0va44r1Sx+3H6E+jN8bGFi5jQkLBrM="
+  [mod."github.com/kr/pretty"]
+    version = "v0.3.1"
+    hash = "sha256-DlER7XM+xiaLjvebcIPiB12oVNjyZHuJHoRGITzzpKU="
+  [mod."github.com/kr/pty"]
+    version = "v1.1.1"
+    hash = "sha256-AVeS+ivwNzIrgWQaLtsmO2f2MYGpxIVqdac/EzaYI1Q="
+  [mod."github.com/kr/text"]
+    version = "v0.2.0"
+    hash = "sha256-fadcWxZOORv44oak3jTxm6YcITcFxdGt4bpn869HxUE="
+  [mod."github.com/kurtosis-tech/stacktrace"]
+    version = "v0.0.0-20211028211901-1c67a77b5409"
+    hash = "sha256-xm9l7tlCb0U25WJvByFikWxnAmOwTmOtlSDBdbyDMMY="
+  [mod."github.com/labstack/echo/v4"]
+    version = "v4.12.0"
+    hash = "sha256-TPXJv/6C53bnmcEYxa9g5Mft8u/rLT96q64tQ9+RtKU="
+  [mod."github.com/labstack/gommon"]
+    version = "v0.4.2"
+    hash = "sha256-395+BETDpv15L2lsCiEccwakXgEQxKHlYBAU0Ot3qhY="
+  [mod."github.com/leodido/go-urn"]
+    version = "v1.2.4"
+    hash = "sha256-N2HO7ChScxI79KGvXI9LxoIlr+lkBNdDZP9OPGwPRK0="
+  [mod."github.com/mailgun/raymond/v2"]
+    version = "v2.0.48"
+    hash = "sha256-HC2vbTL9eCgk1m00h6Mg6W/pu6n/Y7Qr4MJuVQIX4v0="
+  [mod."github.com/mailru/easyjson"]
+    version = "v0.7.7"
+    hash = "sha256-NVCz8MURpxgOjHXqxOZExqV4bnpHggpeAOyZDArjcy4="
+  [mod."github.com/mattn/go-colorable"]
+    version = "v0.1.13"
+    hash = "sha256-qb3Qbo0CELGRIzvw7NVM1g/aayaz4Tguppk9MD2/OI8="
+  [mod."github.com/mattn/go-isatty"]
+    version = "v0.0.20"
+    hash = "sha256-qhw9hWtU5wnyFyuMbKx+7RB8ckQaFQ8D+8GKPkN3HHQ="
+  [mod."github.com/microcosm-cc/bluemonday"]
+    version = "v1.0.25"
+    hash = "sha256-/crG5s6cDrJ55nkDBwugLUpY7U+vQuHpCkKm7nnN8Zc="
+  [mod."github.com/miekg/dns"]
+    version = "v1.1.58"
+    hash = "sha256-UGvyC1Abh2S5VaAUCV9AUuDMrCvpiWQy/UnYM9DfIB8="
+  [mod."github.com/moby/spdystream"]
+    version = "v0.2.0"
+    hash = "sha256-Feme5UoWuBCvnLPKw1ozKkF3SM7PAjjPFQZ3TJhghR0="
+  [mod."github.com/modern-go/concurrent"]
+    version = "v0.0.0-20180306012644-bacd9c7ef1dd"
+    hash = "sha256-OTySieAgPWR4oJnlohaFTeK1tRaVp/b0d1rYY8xKMzo="
+  [mod."github.com/modern-go/reflect2"]
+    version = "v1.0.2"
+    hash = "sha256-+W9EIW7okXIXjWEgOaMh58eLvBZ7OshW2EhaIpNLSBU="
+  [mod."github.com/mohae/deepcopy"]
+    version = "v0.0.0-20170929034955-c48cc78d4826"
+    hash = "sha256-TQMmKqIYwVhmMVh4RYQkAui97Eyj7poLmcAuDcHXsEk="
+  [mod."github.com/munnerz/goautoneg"]
+    version = "v0.0.0-20191010083416-a7dc8b61c822"
+    hash = "sha256-79URDDFenmGc9JZu+5AXHToMrtTREHb3BC84b/gym9Q="
+  [mod."github.com/mxk/go-flowrate"]
+    version = "v0.0.0-20140419014527-cca7078d478f"
+    hash = "sha256-gRTfRfff/LRxC1SXXnQd2tV3UTcTx9qu90DJIVIaGn8="
+  [mod."github.com/oapi-codegen/runtime"]
+    version = "v1.1.1"
+    hash = "sha256-GRvzpQngQPAy59KvvcwhjYqjx4gttIhOtQKjqfQcNvI="
+  [mod."github.com/onsi/ginkgo/v2"]
+    version = "v2.15.0"
+    hash = "sha256-E+f2d0RZ6DSpdh4OasCbT1vGckXsziM3hFt4HkI5x1s="
+  [mod."github.com/onsi/gomega"]
+    version = "v1.31.0"
+    hash = "sha256-a7Bmw1MpIgZNgWenBUEh/R/IpUFVUnDL4zaFznU0ILo="
+  [mod."github.com/pelletier/go-toml/v2"]
+    version = "v2.0.9"
+    hash = "sha256-mLpNBZOK72qPpForSmzQkDrqR5xzmpUdM/0XxB2AYFA="
+  [mod."github.com/perimeterx/marshmallow"]
+    version = "v1.1.5"
+    hash = "sha256-fFWjg0FNohDSV0/wUjQ8fBq1g8h6yIqTrHkxqL2Tt0s="
+  [mod."github.com/peterbourgon/diskv"]
+    version = "v2.0.1+incompatible"
+    hash = "sha256-K4mEVjH0eyxyYHQRxdbmgJT0AJrfucUwGB2BplRRt9c="
+  [mod."github.com/pkg/diff"]
+    version = "v0.0.0-20210226163009-20ebb0f2a09e"
+    hash = "sha256-0aP4CtvBp9lmxoIvKq6mrOyQidLubH1bG92RD/n7bbw="
+  [mod."github.com/pkg/errors"]
+    version = "v0.9.1"
+    hash = "sha256-mNfQtcrQmu3sNg/7IwiieKWOgFQOVVe2yXgKBpe/wZw="
+  [mod."github.com/pkg/profile"]
+    version = "v1.7.0"
+    hash = "sha256-wd8L8WiPoojo/oVUshgiJdM/k367LL1XO5BL5u1L2UU="
+  [mod."github.com/pmezard/go-difflib"]
+    version = "v1.0.0"
+    hash = "sha256-/FtmHnaGjdvEIKAJtrUfEhV7EVo5A/eYrtdnUkuxLDA="
+  [mod."github.com/redis/go-redis/v9"]
+    version = "v9.5.2"
+    hash = "sha256-5LAHJam4xU7MvQxL91UL66Zx4UTLCE6hrtv5A+JCpw4="
+  [mod."github.com/rogpeppe/go-internal"]
+    version = "v1.12.0"
+    hash = "sha256-qvDNCe3l84/LgrA8X4O15e1FeDcazyX91m9LmXGXX6M="
+  [mod."github.com/russross/blackfriday/v2"]
+    version = "v2.1.0"
+    hash = "sha256-R+84l1si8az5yDqd5CYcFrTyNZ1eSYlpXKq6nFt4OTQ="
+  [mod."github.com/samber/lo"]
+    version = "v1.46.0"
+    hash = "sha256-ZvyiOnjqh3nt8OxofUPbXxN14j5bHcmT9TqOCPdwAVQ="
+  [mod."github.com/schollz/closestmatch"]
+    version = "v2.1.0+incompatible"
+    hash = "sha256-SpWqGfqlMkZPQ6TSf7NTaYMbQllBaBgPM8oxTBOTn7w="
+  [mod."github.com/segmentio/analytics-go/v3"]
+    version = "v3.3.0"
+    hash = "sha256-4uaqp8P59nvmihaLwJFBBCFREjHe1q969plWS8qIyHw="
+  [mod."github.com/segmentio/backo-go"]
+    version = "v1.0.0"
+    hash = "sha256-zeabw/evmjj+0Enxug+KzvJQk2LFXz8Yd3t1mJ1YHyI="
+  [mod."github.com/segmentio/conf"]
+    version = "v1.2.0"
+    hash = "sha256-eInV5kwGAToAkh+rQcVatK768cbciEcgo7/k3o7bvYA="
+  [mod."github.com/sirupsen/logrus"]
+    version = "v1.9.3"
+    hash = "sha256-EnxsWdEUPYid+aZ9H4/iMTs1XMvCLbXZRDyvj89Ebms="
+  [mod."github.com/spf13/cobra"]
+    version = "v1.8.0"
+    hash = "sha256-oAE+fEaRfZPE541IPWE0GMeBBYgH2DMhtZNxzp7DFlY="
+  [mod."github.com/spf13/pflag"]
+    version = "v1.0.5"
+    hash = "sha256-w9LLYzxxP74WHT4ouBspH/iQZXjuAh2WQCHsuvyEjAw="
+  [mod."github.com/spkg/bom"]
+    version = "v0.0.0-20160624110644-59b7046e48ad"
+    hash = "sha256-HifA8ur35a/T83Xdaw9vR9EP2SssigF2DG3h1+wJoGA="
+  [mod."github.com/stretchr/objx"]
+    version = "v0.5.2"
+    hash = "sha256-VKYxrrFb1nkX6Wu3tE5DoP9+fCttwSl9pgLN6567nck="
+  [mod."github.com/stretchr/testify"]
+    version = "v1.9.0"
+    hash = "sha256-uUp/On+1nK+lARkTVtb5RxlW15zxtw2kaAFuIASA+J0="
+  [mod."github.com/tdewolff/minify/v2"]
+    version = "v2.12.9"
+    hash = "sha256-eSyTz73LOBXGAMFDJ1/CtmuMiRDzC4HkB+0xXtpvafk="
+  [mod."github.com/tdewolff/parse/v2"]
+    version = "v2.6.8"
+    hash = "sha256-uimZjGFbVz/xiaDHPnbqrEmqeyQF+x5Gp3PfdCsD710="
+  [mod."github.com/tidwall/btree"]
+    version = "v1.7.0"
+    hash = "sha256-bnr6c7a0nqo2HyGqxHk0kEZCEsjLYkPbAVY9WzaZ30o="
+  [mod."github.com/tidwall/match"]
+    version = "v1.1.1"
+    hash = "sha256-M2klhPId3Q3T3VGkSbOkYl/2nLHnsG+yMbXkPkyrRdg="
+  [mod."github.com/tidwall/redcon"]
+    version = "v1.6.2"
+    hash = "sha256-EhMOHoYAucg7ahRc9ALiEOluvJCAVd9nwy7BKfDt6bc="
+  [mod."github.com/twitchyliquid64/golang-asm"]
+    version = "v0.15.1"
+    hash = "sha256-HLk6oUe7EoITrNvP0y8D6BtIgIcmDZYtb/xl/dufIoY="
+  [mod."github.com/ugorji/go/codec"]
+    version = "v1.2.11"
+    hash = "sha256-hfcj+YsznH6MeERSdIPjSrsM7gbDcIzH/TbgHzYbPww="
+  [mod."github.com/valyala/bytebufferpool"]
+    version = "v1.0.0"
+    hash = "sha256-I9FPZ3kCNRB+o0dpMwBnwZ35Fj9+ThvITn8a3Jr8mAY="
+  [mod."github.com/valyala/fasttemplate"]
+    version = "v1.2.2"
+    hash = "sha256-gp+lNXE8zjO+qJDM/YbS6V43HFsYP6PKn4ux1qa5lZ0="
+  [mod."github.com/vmihailenco/msgpack/v5"]
+    version = "v5.3.5"
+    hash = "sha256-Uj5xRZbtxE8evniQPuBVkxkEdMa/H/pt9s84J16swm8="
+  [mod."github.com/vmihailenco/tagparser/v2"]
+    version = "v2.0.0"
+    hash = "sha256-M9QyaKhSmmYwsJk7gkjtqu9PuiqZHSmTkous8VWkWY0="
+  [mod."github.com/x448/float16"]
+    version = "v0.8.4"
+    hash = "sha256-VKzMTMS9pIB/cwe17xPftCSK9Mf4Y6EuBEJlB4by5mE="
+  [mod."github.com/yosssi/ace"]
+    version = "v0.0.5"
+    hash = "sha256-0HnNZUypGGoQxFX214/eF7RJ9KxYpb56Q5Rn2tryOLM="
+  [mod."github.com/yuin/goldmark"]
+    version = "v1.4.13"
+    hash = "sha256-GVwFKZY6moIS6I0ZGuio/WtDif+lkZRfqWS6b4AAJyI="
+  [mod."go.opencensus.io"]
+    version = "v0.24.0"
+    hash = "sha256-4H+mGZgG2c9I1y0m8avF4qmt8LUKxxVsTqR8mKgP4yo="
+  [mod."golang.org/x/arch"]
+    version = "v0.4.0"
+    hash = "sha256-jKi0m79VwPy8XxGh1e5YRZX5jfb2drWfmLWxNR3HvAU="
+  [mod."golang.org/x/crypto"]
+    version = "v0.23.0"
+    hash = "sha256-6hZjb/OazWFBef0C/aH63l49YQnzCh2vpIduzyfSSG8="
+  [mod."golang.org/x/exp"]
+    version = "v0.0.0-20240416160154-fe59bbe5cc7f"
+    hash = "sha256-168CD9hlLJaQ7stQk/ztlP3zgaWXUMbIHa38gAeRRs4="
+  [mod."golang.org/x/mod"]
+    version = "v0.17.0"
+    hash = "sha256-CLaPeF6uTFuRDv4oHwOQE6MCMvrzkUjWN3NuyywZjKU="
+  [mod."golang.org/x/net"]
+    version = "v0.25.0"
+    hash = "sha256-IjFfXLYNj27WLF7vpkZ6mfFXBnp+7QER3OQ0RgjxN54="
+  [mod."golang.org/x/oauth2"]
+    version = "v0.19.0"
+    hash = "sha256-IYdkq8R8BXnwoBt/ZLAMJr0DkLZDMVkjeBJNQ/Z9Bes="
+  [mod."golang.org/x/sync"]
+    version = "v0.7.0"
+    hash = "sha256-2ETllEu2GDWoOd/yMkOkLC2hWBpKzbVZ8LhjLu0d2A8="
+  [mod."golang.org/x/sys"]
+    version = "v0.20.0"
+    hash = "sha256-mowlaoG2k4n1c1rApWef5EMiXd3I77CsUi8jPh6pTYA="
+  [mod."golang.org/x/telemetry"]
+    version = "v0.0.0-20240228155512-f48c80bd79b2"
+    hash = "sha256-31mlnHWpwrXwsKBXdvFVphcACQ/DQ7tv1AGBxL6Cs4U="
+  [mod."golang.org/x/term"]
+    version = "v0.20.0"
+    hash = "sha256-kU+OVJbYktTIn4ZTAdomsOjL069Vj45sdroEMRKaRDI="
+  [mod."golang.org/x/text"]
+    version = "v0.16.0"
+    hash = "sha256-hMTO45upjEuA4sJzGplJT+La2n3oAfHccfYWZuHcH+8="
+  [mod."golang.org/x/time"]
+    version = "v0.5.0"
+    hash = "sha256-W6RgwgdYTO3byIPOFxrP2IpAZdgaGowAaVfYby7AULU="
+  [mod."golang.org/x/tools"]
+    version = "v0.21.1-0.20240508182429-e35e4ccd0d2d"
+    hash = "sha256-KfnS+3fREPAWQUBoUedPupQp9yLrugxMmmEoHvyzKNE="
+  [mod."golang.org/x/xerrors"]
+    version = "v0.0.0-20220907171357-04be3eba64a2"
+    hash = "sha256-6+zueutgefIYmgXinOflz8qGDDDj0Zhv+2OkGhBTKno="
+  [mod."google.golang.org/api"]
+    version = "v0.126.0"
+    hash = "sha256-G/J0Aba+S35gE7VevU2WrrbwQRsJCSj14DVSLTqz0vE="
+  [mod."google.golang.org/appengine"]
+    version = "v1.6.7"
+    hash = "sha256-zIxGRHiq4QBvRqkrhMGMGCaVL4iM4TtlYpAi/hrivS4="
+  [mod."google.golang.org/genproto"]
+    version = "v0.0.0-20230530153820-e85fd2cbaebc"
+    hash = "sha256-xuUQD0+WiF+LGKhQCCwaA5WKlZz6EG9WhClfEonHedk="
+  [mod."google.golang.org/genproto/googleapis/api"]
+    version = "v0.0.0-20240318140521-94a12d6c2237"
+    hash = "sha256-Tl2ABoESriYlPfeawE9xd5gPQYGzW4j/Il6gXEw33f0="
+  [mod."google.golang.org/genproto/googleapis/rpc"]
+    version = "v0.0.0-20240314234333-6e1732d8331c"
+    hash = "sha256-P5SBku16dYnK4koUQxTeGwPxAAWH8rxbDm2pOzFLo/Q="
+  [mod."google.golang.org/grpc"]
+    version = "v1.63.2"
+    hash = "sha256-RmtVjYLam97k7IHTHU7Gn16xNX+GvA9AiLKlQwOiZXU="
+  [mod."google.golang.org/grpc/cmd/protoc-gen-go-grpc"]
+    version = "v1.3.0"
+    hash = "sha256-6M1gOZMu3hN08M/giGcVv4ic5ChGcUfKLUlUtZxvF7E="
+  [mod."google.golang.org/protobuf"]
+    version = "v1.33.0"
+    hash = "sha256-cWwQjtUwSIEkAlAadrlxK1PYZXTRrV4NKzt7xDpJgIU="
+  [mod."gopkg.in/check.v1"]
+    version = "v1.0.0-20201130134442-10cb98267c6c"
+    hash = "sha256-VlIpM2r/OD+kkyItn6vW35dyc0rtkJufA93rjFyzncs="
+  [mod."gopkg.in/inf.v0"]
+    version = "v0.9.1"
+    hash = "sha256-z84XlyeWLcoYOvWLxPkPFgLkpjyb2Y4pdeGMyySOZQI="
+  [mod."gopkg.in/ini.v1"]
+    version = "v1.67.0"
+    hash = "sha256-V10ahGNGT+NLRdKUyRg1dos5RxLBXBk1xutcnquc/+4="
+  [mod."gopkg.in/yaml.v2"]
+    version = "v2.4.0"
+    hash = "sha256-uVEGglIedjOIGZzHW4YwN1VoRSTK8o0eGZqzd+TNdd0="
+  [mod."gopkg.in/yaml.v3"]
+    version = "v3.0.1"
+    hash = "sha256-FqL9TKYJ0XkNwJFnq9j0VvJ5ZUU1RvH/52h/f5bkYAU="
+  [mod."istio.io/api"]
+    version = "v1.22.1-0.20240524024004-b6815be0740d"
+    hash = "sha256-crSFKGbjxvJRenCJVCTc4bgVl4//h3jDugNMjmUSQM4="
+  [mod."istio.io/client-go"]
+    version = "v1.22.1"
+    hash = "sha256-yBen7y8xbvpgTzUYxEUOBqwkJGHfVjqxFUxKrxkHdls="
+  [mod."k8s.io/api"]
+    version = "v0.30.2"
+    hash = "sha256-sq8jdb0wnAIhTO/hactsJ34mRuUgEuUNOrKaQasbHpQ="
+  [mod."k8s.io/apiextensions-apiserver"]
+    version = "v0.30.0"
+    hash = "sha256-1/T2iSEHRGZttj9pgl5VpQ3yAx7+GRMi7g9kLeaRvMM="
+  [mod."k8s.io/apimachinery"]
+    version = "v0.30.2"
+    hash = "sha256-EBWG9PlSfRwMed/u6oF8ME8n44/U5HGBCacH+Mns2UI="
+  [mod."k8s.io/client-go"]
+    version = "v0.30.2"
+    hash = "sha256-KwgEXnowk01jImaHhOStbVWc3dDVZKF2nVvfsJAvtgo="
+  [mod."k8s.io/code-generator"]
+    version = "v0.30.0"
+    hash = "sha256-MCco4LG1k9A6tP/AHqAAZb0EyOG/IOhIC5R76J56cYs="
+  [mod."k8s.io/gengo"]
+    version = "v0.0.0-20230829151522-9cce18d56c01"
+    hash = "sha256-JgsgX2R/iu1I96dQ45ZSe4AW1PIgEpArsF3Xa+yzTxI="
+  [mod."k8s.io/gengo/v2"]
+    version = "v2.0.0-20240228010128-51d4e06bde70"
+    hash = "sha256-igAJQwUliynE2iDbBYc2HONd744+r7o3mQtFyYDYLb4="
+  [mod."k8s.io/klog"]
+    version = "v0.2.0"
+    hash = "sha256-YabDBrcEBN72ClwZ1bs9bA+2gjH9ZD7omGCjtWY/YUo="
+  [mod."k8s.io/klog/v2"]
+    version = "v2.120.1"
+    hash = "sha256-PU3q5ODCHEO8z//zUKsCq2tky6ZNx4xFl3nHSPJpuW8="
+  [mod."k8s.io/kube-openapi"]
+    version = "v0.0.0-20240423202451-8948a665c108"
+    hash = "sha256-EXaKmh3z505YcvpGBCP+nwk6EIqH7H09kakalWKXLxk="
+  [mod."k8s.io/utils"]
+    version = "v0.0.0-20240423183400-0849a56e8f22"
+    hash = "sha256-4CiDxKJMHKJ173hu3KsVBD4XdAfGZRMiHIFeqW3AwYs="
+  [mod."sigs.k8s.io/controller-runtime"]
+    version = "v0.18.0"
+    hash = "sha256-383Pun8npG9f4ITz3YGHunU48X6rvJtHd03EdNLjMhQ="
+  [mod."sigs.k8s.io/controller-tools"]
+    version = "v0.15.0"
+    hash = "sha256-McJAHNx3tTjEww+/Sbz6vG5YR5z+WUovuzK2lH21Vnk="
+  [mod."sigs.k8s.io/gateway-api"]
+    version = "v1.1.0"
+    hash = "sha256-v/Naf9D35XsQLieooRseVTfDQ7KwCqViX9mRviVeLDw="
+  [mod."sigs.k8s.io/json"]
+    version = "v0.0.0-20221116044647-bc3834ca7abd"
+    hash = "sha256-XDBMN2o450IHiAwEpBVsvo9e7tYZa+EXWrifUNTdNMU="
+  [mod."sigs.k8s.io/structured-merge-diff/v4"]
+    version = "v4.4.1"
+    hash = "sha256-FcZHHZCKNNZW6/s1T1sKiS5Vj1TpHPmxVWr6YlL60xA="
+  [mod."sigs.k8s.io/yaml"]
+    version = "v1.4.0"
+    hash = "sha256-Hd/M0vIfIVobDd87eb58p1HyVOjYWNlGq2bRXfmtVno="

--- a/kardinal_version/kardinal_version.go
+++ b/kardinal_version/kardinal_version.go
@@ -1,0 +1,5 @@
+package kardinal_version
+
+const (
+	KardinalVersion = "0.4.3"
+)


### PR DESCRIPTION
This is a duplicate of the version cmd but part 1 - it adds the `kardinal_version` module but does not hook it up to the build process yet.